### PR TITLE
Fix mozilla/servo#670: build with different source and target dirs

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -7,8 +7,8 @@ AR ?= ar
 RUSTC ?= rustc
 RUSTFLAGS ?=
 
-GENERATED_RUST_SRC=color_data.rs
-RUST_SRC=$(shell find $(VPATH)/. -type f -name '*.rs') $(GENERATED_RUST_SRC)
+COLOR_DATA_RS=$(VPATH)/color_data.rs
+RUST_SRC=$(shell find $(VPATH)/. -type f -name '*.rs') $(COLOR_DATA_RS)
 
 .PHONY: all
 all:    libcssparser.dummy
@@ -33,5 +33,5 @@ clean:
 	rm -f *.o *.a *.so *.dylib *.dll *.dummy *-test
 
 
-color_data.rs: make_color_data.py
+$(COLOR_DATA_RS): make_color_data.py
 	python $< > $@


### PR DESCRIPTION
Keep the generated `color_data.rs` file in the source directory, where it is `.gitignore`’d.
