### PR TITLE
Make modules public. See https://github.com/mozilla/rust/issues/8478

### DIFF
--- a/cssparser.rc
+++ b/cssparser.rc
@@ -13,11 +13,11 @@ pub use parser::*;
 pub use color::*;
 pub use nth::*;
 
-mod ast;
-mod tokenizer;
-mod parser;
-mod color;
-mod nth;
+pub mod ast;
+pub mod tokenizer;
+pub mod parser;
+pub mod color;
+pub mod nth;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
- Non-public modules define public functions,
- The crate’s top-level re-exports said functions as public

This should work, but currently triggers link-time "undefined reference" errors.
