### PR TITLE
Upgrade to Rust aa67254 2014-05-08

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 *.a
 *.so
+*.rlib
 *.dylib
 *.dSYM
 *.dll

--- a/ast.rs
+++ b/ast.rs
@@ -4,11 +4,12 @@
 
 use std::fmt;
 use std::slice;
+use std::vec;
 
 
 #[deriving(Eq)]
 pub struct NumericValue {
-    pub representation: ~str,
+    pub representation: StrBuf,
     pub value: f64,
     pub int_value: Option<i64>,
 }
@@ -27,16 +28,16 @@ pub type Node = (ComponentValue, SourceLocation);  // TODO this is not a good na
 #[deriving(Eq)]
 pub enum ComponentValue {
     // Preserved tokens.
-    Ident(~str),
-    AtKeyword(~str),
-    Hash(~str),
-    IDHash(~str),  // Hash that is a valid ID selector.
-    String(~str),
-    URL(~str),
+    Ident(StrBuf),
+    AtKeyword(StrBuf),
+    Hash(StrBuf),
+    IDHash(StrBuf),  // Hash that is a valid ID selector.
+    String(StrBuf),
+    URL(StrBuf),
     Delim(char),
     Number(NumericValue),
     Percentage(NumericValue),
-    Dimension(NumericValue, ~str),
+    Dimension(NumericValue, StrBuf),
     UnicodeRange(u32, u32),  // (start, end) of range
     WhiteSpace,
     Colon,  // :
@@ -52,12 +53,12 @@ pub enum ComponentValue {
     CDC,  // -->
 
     // Function
-    Function(~str, ~[ComponentValue]),  // name, arguments
+    Function(StrBuf, Vec<ComponentValue>),  // name, arguments
 
     // Simple block
-    ParenthesisBlock(~[ComponentValue]),  // (…)
-    SquareBracketBlock(~[ComponentValue]),  // […]
-    CurlyBracketBlock(~[Node]),  // {…}
+    ParenthesisBlock(Vec<ComponentValue>),  // (…)
+    SquareBracketBlock(Vec<ComponentValue>),  // […]
+    CurlyBracketBlock(Vec<Node>),  // {…}
 
     // These are always invalid
     BadURL,
@@ -71,24 +72,24 @@ pub enum ComponentValue {
 #[deriving(Eq)]
 pub struct Declaration {
     pub location: SourceLocation,
-    pub name: ~str,
-    pub value: ~[ComponentValue],
+    pub name: StrBuf,
+    pub value: Vec<ComponentValue>,
     pub important: bool,
 }
 
 #[deriving(Eq)]
 pub struct QualifiedRule {
     pub location: SourceLocation,
-    pub prelude: ~[ComponentValue],
-    pub block: ~[Node],
+    pub prelude: Vec<ComponentValue>,
+    pub block: Vec<Node>,
 }
 
 #[deriving(Eq)]
 pub struct AtRule {
     pub location: SourceLocation,
-    pub name: ~str,
-    pub prelude: ~[ComponentValue],
-    pub block: Option<~[Node]>,
+    pub name: StrBuf,
+    pub prelude: Vec<ComponentValue>,
+    pub block: Option<Vec<Node>>,
 }
 
 #[deriving(Eq)]
@@ -156,14 +157,14 @@ pub trait MoveSkipWhitespaceIterable {
     fn move_skip_whitespace(self) -> MoveSkipWhitespaceIterator;
 }
 
-impl MoveSkipWhitespaceIterable for ~[ComponentValue] {
+impl MoveSkipWhitespaceIterable for Vec<ComponentValue> {
     fn move_skip_whitespace(self) -> MoveSkipWhitespaceIterator {
         MoveSkipWhitespaceIterator{ iter_with_whitespace: self.move_iter() }
     }
 }
 
 pub struct MoveSkipWhitespaceIterator {
-    iter_with_whitespace: slice::MoveItems<ComponentValue>,
+    iter_with_whitespace: vec::MoveItems<ComponentValue>,
 }
 
 impl Iterator<ComponentValue> for MoveSkipWhitespaceIterator {

--- a/color.rs
+++ b/color.rs
@@ -28,9 +28,10 @@ pub enum Color {
 impl Color {
     pub fn parse(component_value: &ComponentValue) -> Option<Color> {
         match *component_value {
-            Hash(ref value) | IDHash(ref value) => parse_color_hash(*value),
-            Ident(ref value) => parse_color_keyword(*value),
-            Function(ref name, ref arguments) => parse_color_function(*name, *arguments),
+            Hash(ref value) | IDHash(ref value) => parse_color_hash(value.as_slice()),
+            Ident(ref value) => parse_color_keyword(value.as_slice()),
+            Function(ref name, ref arguments)
+                => parse_color_function(name.as_slice(), arguments.as_slice()),
             _ => None
         }
     }

--- a/from_bytes.rs
+++ b/from_bytes.rs
@@ -33,7 +33,7 @@ use parser::{parse_stylesheet_rules, StylesheetParser};
 ///     and the `Encoding` object that was used.
 pub fn decode_stylesheet_bytes(css: &[u8], protocol_encoding_label: Option<&str>,
                                environment_encoding: Option<EncodingRef>)
-                            -> (~str, EncodingRef) {
+                            -> (StrBuf, EncodingRef) {
     // http://dev.w3.org/csswg/css-syntax/#the-input-byte-stream
     match protocol_encoding_label {
         None => (),
@@ -71,7 +71,7 @@ pub fn decode_stylesheet_bytes(css: &[u8], protocol_encoding_label: Option<&str>
 
 
 #[inline]
-fn decode_replace(input: &[u8], fallback_encoding: EncodingRef)-> (~str, EncodingRef) {
+fn decode_replace(input: &[u8], fallback_encoding: EncodingRef)-> (StrBuf, EncodingRef) {
     let (result, used_encoding) = decode(input, DecodeReplace, fallback_encoding);
     (result.unwrap(), used_encoding)
 }
@@ -97,5 +97,5 @@ pub fn parse_stylesheet_rules_from_bytes(
      -> (StylesheetParser<Tokenizer>, EncodingRef) {
     let (css_unicode, encoding) = decode_stylesheet_bytes(
         css_bytes, protocol_encoding_label, environment_encoding);
-    (parse_stylesheet_rules(tokenize(css_unicode)), encoding)
+    (parse_stylesheet_rules(tokenize(css_unicode.as_slice())), encoding)
 }

--- a/nth.rs
+++ b/nth.rs
@@ -116,7 +116,7 @@ fn parse_n_dash_digits(string: &str) -> Option<i32> {
 
 #[inline]
 fn has_sign(value: &NumericValue) -> bool {
-    match value.representation[0] as char {
+    match value.representation.as_bytes()[0] as char {
         '+' | '-' => true,
         _ => false
     }

--- a/parser.rs
+++ b/parser.rs
@@ -20,9 +20,9 @@ use std::ascii::StrAsciiExt;
 use ast::*;
 
 
-pub struct StylesheetParser<T>{ priv iter: T }
-pub struct RuleListParser<T>{ priv iter: T }
-pub struct DeclarationListParser<T>{ priv iter: T }
+pub struct StylesheetParser<T>{ iter: T }
+pub struct RuleListParser<T>{ iter: T }
+pub struct DeclarationListParser<T>{ iter: T }
 
 /// Parse top-level of a CSS stylesheet.
 /// Return a Iterator<Result<Rule, SyntaxError>>
@@ -173,9 +173,9 @@ for DeclarationListParser<T> {
 }
 
 
-fn parse_at_rule<T: Iterator<Node>>(iter: &mut T, name: ~str, location: SourceLocation)
+fn parse_at_rule<T: Iterator<Node>>(iter: &mut T, name: StrBuf, location: SourceLocation)
                  -> AtRule {
-    let mut prelude = ~[];
+    let mut prelude = Vec::new();
     let mut block = None;
     for_iter!(iter, (component_value, _location), {
         match component_value {
@@ -193,10 +193,10 @@ fn parse_qualified_rule<T: Iterator<Node>>(iter: &mut T, first: ComponentValue,
                                            -> Result<QualifiedRule, SyntaxError> {
     match first {
         CurlyBracketBlock(content)
-        => return Ok(QualifiedRule { location: location, prelude: ~[], block: content }),
+        => return Ok(QualifiedRule { location: location, prelude: Vec::new(), block: content }),
         _ => (),
     }
-    let mut prelude = ~[first];
+    let mut prelude = vec!(first);
     for_iter!(iter, (component_value, _location), {
         match component_value {
             CurlyBracketBlock(content)
@@ -219,7 +219,7 @@ fn parse_declaration<T: Iterator<Node>>(iter: &mut T, first: ComponentValue,
         Some((Colon, _)) => (),
         _ => return error(location, ErrInvalidDeclarationSyntax),
     }
-    let mut value = ~[];
+    let mut value = Vec::new();
     let mut important = false;
     for_iter!(iter, (component_value, _location), {
         match component_value {
@@ -243,7 +243,7 @@ fn parse_declaration_important<T: Iterator<Node>>(iter: &mut T) -> bool {
         Some((Ident(value), _)) => value,
         _ => return false,
     };
-    if !ident_value.eq_ignore_ascii_case("important") { return false }
+    if !ident_value.as_slice().eq_ignore_ascii_case("important") { return false }
     match next_non_whitespace(iter) {
         Some((Semicolon, _)) => true,
         None => true,

--- a/serializer.rs
+++ b/serializer.rs
@@ -7,13 +7,13 @@ use ast::*;
 
 
 impl ast::ComponentValue {
-    pub fn to_css(&mut self) -> ~str {
-        let mut css = ~"";
+    pub fn to_css(&mut self) -> StrBuf {
+        let mut css = StrBuf::new();
         self.to_css_push(&mut css);
         css
     }
 
-    pub fn to_css_push(&self, css: &mut ~str) {
+    pub fn to_css_push(&self, css: &mut StrBuf) {
         match *self {
             Ident(ref value) => serialize_identifier(value.as_slice(), css),
             AtKeyword(ref value) => {
@@ -22,7 +22,7 @@ impl ast::ComponentValue {
             },
             Hash(ref value) => {
                 css.push_char('#');
-                for c in value.chars() {
+                for c in value.as_slice().chars() {
                     serialize_char(c, css, /* is_identifier_start = */ false);
                 }
             },
@@ -38,13 +38,13 @@ impl ast::ComponentValue {
             },
             Delim(value) => css.push_char(value),
 
-            Number(ref value) => css.push_str(value.representation),
+            Number(ref value) => css.push_str(value.representation.as_slice()),
             Percentage(ref value) => {
-                css.push_str(value.representation);
+                css.push_str(value.representation.as_slice());
                 css.push_char('%');
             },
             Dimension(ref value, ref unit) => {
-                css.push_str(value.representation);
+                css.push_str(value.representation.as_slice());
                 // Disambiguate with scientific notation.
                 let unit = unit.as_slice();
                 if unit == "e" || unit == "E" || unit.starts_with("e-") || unit.starts_with("E-") {
@@ -109,7 +109,7 @@ impl ast::ComponentValue {
 }
 
 
-pub fn serialize_identifier(value: &str, css: &mut ~str) {
+pub fn serialize_identifier(value: &str, css: &mut StrBuf) {
     // TODO: avoid decoding/re-encoding UTF-8?
     let mut iter = value.chars();
     let mut c = iter.next().unwrap();
@@ -127,7 +127,7 @@ pub fn serialize_identifier(value: &str, css: &mut ~str) {
 
 
 #[inline]
-fn serialize_char(c: char, css: &mut ~str, is_identifier_start: bool) {
+fn serialize_char(c: char, css: &mut StrBuf, is_identifier_start: bool) {
     match c {
         '0'..'9' if is_identifier_start => css.push_str(format!("\\\\3{} ", c)),
         '-' if is_identifier_start => css.push_str("\\-"),
@@ -141,7 +141,7 @@ fn serialize_char(c: char, css: &mut ~str, is_identifier_start: bool) {
 }
 
 
-pub fn serialize_string(value: &str, css: &mut ~str) {
+pub fn serialize_string(value: &str, css: &mut StrBuf) {
     css.push_char('"');
     // TODO: avoid decoding/re-encoding UTF-8?
     for c in value.chars() {
@@ -159,18 +159,18 @@ pub fn serialize_string(value: &str, css: &mut ~str) {
 
 
 pub trait ToCss {
-    fn to_css(&mut self) -> ~str {
-        let mut css = ~"";
+    fn to_css(&mut self) -> StrBuf {
+        let mut css = StrBuf::new();
         self.to_css_push(&mut css);
         css
     }
 
-    fn to_css_push(&mut self, css: &mut ~str);
+    fn to_css_push(&mut self, css: &mut StrBuf);
 }
 
 
 impl<'a, I: Iterator<&'a ComponentValue>> ToCss for I {
-    fn to_css_push(&mut self, css: &mut ~str) {
+    fn to_css_push(&mut self, css: &mut StrBuf) {
         let mut previous = match self.next() {
             None => return,
             Some(first) => { first.to_css_push(css); first }


### PR DESCRIPTION
r? @Ms2ger

This includes some breaking public API changes (`~str` → `StrBuf` and `~[T]` → `Vec<T>`)
