### PR TITLE
Export `parse_color_keyword` for use in legacy HTML color parsing.

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -60,7 +60,7 @@ impl Color {
 
 
 #[inline]
-fn parse_color_keyword(value: &str) -> Result<Color, ()> {
+pub fn parse_color_keyword(value: &str) -> Result<Color, ()> {
     let lower_value = value.to_ascii_lower();
     let (r, g, b) = match lower_value.as_slice() {
         "black" => (0., 0., 0.),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate test;
 #[cfg(test)]
 extern crate serialize;
 
+pub use color::{parse_color_keyword};
 pub use tokenizer::{tokenize, Tokenizer};
 pub use parser::{parse_stylesheet_rules, StylesheetParser,
                  parse_rule_list, RuleListParser,


### PR DESCRIPTION
I could have gotten around the privacy restriction by synthesizing a
fake CSS AST and parsing that, but that would have been less efficient.

This won't merge because it's incompatible with the enum changes; I'll have to create a separate branch once the review is done.

r? @SimonSapin 
