### PR TITLE
Clamp to MAX / INFINITY rather than panic on overflow in number parsing

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -309,18 +309,18 @@ fn parse_color_function(name: &str, arguments: &mut Parser) -> Result<Color, ()>
         // Either integers or percentages, but all the same type.
         match try!(arguments.next()) {
             Token::Number(ref v) if v.int_value.is_some() => {
-                red = (v.value / 255.) as f32;
+                red = v.value / 255.;
                 try!(arguments.expect_comma());
                 green = try!(arguments.expect_integer()) as f32 / 255.;
                 try!(arguments.expect_comma());
                 blue = try!(arguments.expect_integer()) as f32 / 255.;
             }
             Token::Percentage(ref v) => {
-                red = v.unit_value as f32;
+                red = v.unit_value;
                 try!(arguments.expect_comma());
-                green = try!(arguments.expect_percentage()) as f32;
+                green = try!(arguments.expect_percentage());
                 try!(arguments.expect_comma());
-                blue = try!(arguments.expect_percentage()) as f32;
+                blue = try!(arguments.expect_percentage());
             }
             _ => return Err(())
         };
@@ -333,7 +333,7 @@ fn parse_color_function(name: &str, arguments: &mut Parser) -> Result<Color, ()>
         let lightness = (try!(arguments.expect_percentage())).max(0.).min(1.);
 
         // http://www.w3.org/TR/css3-color/#hsl-color
-        fn hue_to_rgb(m1: f64, m2: f64, mut h: f64) -> f64 {
+        fn hue_to_rgb(m1: f32, m2: f32, mut h: f32) -> f32 {
             if h < 0. { h += 1. }
             if h > 1. { h -= 1. }
 
@@ -345,14 +345,14 @@ fn parse_color_function(name: &str, arguments: &mut Parser) -> Result<Color, ()>
         let m2 = if lightness <= 0.5 { lightness * (saturation + 1.) }
                  else { lightness + saturation - lightness * saturation };
         let m1 = lightness * 2. - m2;
-        red = hue_to_rgb(m1, m2, hue + 1. / 3.) as f32;
-        green = hue_to_rgb(m1, m2, hue) as f32;
-        blue = hue_to_rgb(m1, m2, hue - 1. / 3.) as f32;
+        red = hue_to_rgb(m1, m2, hue + 1. / 3.);
+        green = hue_to_rgb(m1, m2, hue);
+        blue = hue_to_rgb(m1, m2, hue - 1. / 3.);
     }
 
     let alpha = if has_alpha {
         try!(arguments.expect_comma());
-        (try!(arguments.expect_number())).max(0.).min(1.) as f32
+        (try!(arguments.expect_number())).max(0.).min(1.)
     } else {
         1.
     };

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -57,7 +57,7 @@ fn parse_b(input: &mut Parser, a: i32) -> Result<(i32, i32), ()> {
     match input.next() {
         Ok(Token::Delim('+')) => parse_signless_b(input, a, 1),
         Ok(Token::Delim('-')) => parse_signless_b(input, a, -1),
-        Ok(Token::Number(ref value)) if value.signed => {
+        Ok(Token::Number(ref value)) if value.has_sign => {
             Ok((a, try!(value.int_value.ok_or(())) as i32))
         }
         _ => {
@@ -69,7 +69,7 @@ fn parse_b(input: &mut Parser, a: i32) -> Result<(i32, i32), ()> {
 
 fn parse_signless_b(input: &mut Parser, a: i32, b_sign: i32) -> Result<(i32, i32), ()> {
     match try!(input.next()) {
-        Token::Number(ref value) if !value.signed => {
+        Token::Number(ref value) if !value.has_sign => {
             Ok((a, b_sign * (try!(value.int_value.ok_or(())) as i32)))
         }
         _ => Err(())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -495,7 +495,7 @@ impl<'i, 't> Parser<'i, 't> {
 
     /// Parse a <number-token> and return the integer value.
     #[inline]
-    pub fn expect_number(&mut self) -> Result<f64, ()> {
+    pub fn expect_number(&mut self) -> Result<f32, ()> {
         match try!(self.next()) {
             Token::Number(NumericValue { value, .. }) => Ok(value),
             _ => Err(())
@@ -504,7 +504,7 @@ impl<'i, 't> Parser<'i, 't> {
 
     /// Parse a <number-token> that does not have a fractional part, and return the integer value.
     #[inline]
-    pub fn expect_integer(&mut self) -> Result<i64, ()> {
+    pub fn expect_integer(&mut self) -> Result<i32, ()> {
         match try!(self.next()) {
             Token::Number(NumericValue { int_value, .. }) => int_value.ok_or(()),
             _ => Err(())
@@ -514,7 +514,7 @@ impl<'i, 't> Parser<'i, 't> {
     /// Parse a <percentage-token> and return the value.
     /// `0%` and `100%` map to `0.0` and `1.0` (not `100.0`), respectively.
     #[inline]
-    pub fn expect_percentage(&mut self) -> Result<f64, ()> {
+    pub fn expect_percentage(&mut self) -> Result<f32, ()> {
         match try!(self.next()) {
             Token::Percentage(PercentageValue { unit_value, .. }) => Ok(unit_value),
             _ => Err(())

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -49,7 +49,7 @@ pub trait ToCss {
 fn write_numeric<W>(value: NumericValue, dest: &mut W) -> text_writer::Result
 where W: TextWriter {
     // `value.value >= 0` is true for negative 0.
-    if value.signed && value.value.is_positive() {
+    if value.has_sign && value.value.is_positive() {
         try!(dest.write_str("+"));
     }
 
@@ -94,11 +94,11 @@ impl<'a> ToCss for Token<'a> {
             Token::Delim(value) => try!(dest.write_char(value)),
 
             Token::Number(value) => try!(write_numeric(value, dest)),
-            Token::Percentage(PercentageValue { unit_value, int_value, signed }) => {
+            Token::Percentage(PercentageValue { unit_value, int_value, has_sign }) => {
                 let value = NumericValue {
                     value: unit_value * 100.,
                     int_value: int_value,
-                    signed: signed,
+                    has_sign: has_sign,
                 };
                 try!(write_numeric(value, dest));
                 try!(dest.write_char('%'));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -410,6 +410,62 @@ fn line_numbers() {
 }
 
 #[test]
+fn overflow() {
+    use std::iter::repeat;
+    use std::f32;
+
+    let css = r"
+         2147483646
+         2147483647
+         2147483648
+         10000000000000
+         1000000000000000000000000000000000000000
+         1{309 zeros}
+
+         -2147483647
+         -2147483648
+         -2147483649
+         -10000000000000
+         -1000000000000000000000000000000000000000
+         -1{309 zeros}
+
+         3.30282347e+38
+         3.40282347e+38
+         3.402824e+38
+
+         -3.30282347e+38
+         -3.40282347e+38
+         -3.402824e+38
+
+    ".replace("{309 zeros}", &repeat('0').take(309).collect::<String>());
+    let mut input = Parser::new(&css);
+
+    assert_eq!(input.expect_integer(), Ok(2147483646));
+    assert_eq!(input.expect_integer(), Ok(2147483647));
+    assert_eq!(input.expect_integer(), Ok(2147483647)); // Clamp on overflow
+    assert_eq!(input.expect_integer(), Ok(2147483647));
+    assert_eq!(input.expect_integer(), Ok(2147483647));
+    assert_eq!(input.expect_integer(), Ok(2147483647));
+
+    assert_eq!(input.expect_integer(), Ok(-2147483647));
+    assert_eq!(input.expect_integer(), Ok(-2147483648));
+    assert_eq!(input.expect_integer(), Ok(-2147483648)); // Clamp on overflow
+    assert_eq!(input.expect_integer(), Ok(-2147483648));
+    assert_eq!(input.expect_integer(), Ok(-2147483648));
+    assert_eq!(input.expect_integer(), Ok(-2147483648));
+
+    assert_eq!(input.expect_number(), Ok(3.30282347e+38));
+    assert_eq!(input.expect_number(), Ok(f32::MAX));
+    assert_eq!(input.expect_number(), Ok(f32::INFINITY));
+    assert!(f32::MAX != f32::INFINITY);
+
+    assert_eq!(input.expect_number(), Ok(-3.30282347e+38));
+    assert_eq!(input.expect_number(), Ok(f32::MIN));
+    assert_eq!(input.expect_number(), Ok(f32::NEG_INFINITY));
+    assert!(f32::MIN != f32::NEG_INFINITY);
+}
+
+#[test]
 fn line_delimited() {
     let mut input = Parser::new(" { foo ; bar } baz;,");
     assert_eq!(input.next(), Ok(Token::CurlyBracketBlock));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -545,11 +545,11 @@ fn one_component_value_to_json(token: Token, input: &mut Parser) -> Json {
         Token::Delim(value) => value.to_string().to_json(),
 
         Token::Number(value) => Json::Array(vec!["number".to_json()] + numeric(value).as_slice()),
-        Token::Percentage(PercentageValue { unit_value, int_value, signed }) => Json::Array(
+        Token::Percentage(PercentageValue { unit_value, int_value, has_sign }) => Json::Array(
             vec!["percentage".to_json()] + numeric(NumericValue {
                 value: unit_value * 100.,
                 int_value: int_value,
-                signed: signed,
+                has_sign: has_sign,
             }).as_slice()),
         Token::Dimension(value, unit) => Json::Array(
             vec!["dimension".to_json()] + numeric(value).as_slice() + [unit.to_json()].as_slice()),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -685,7 +685,7 @@ fn consume_numeric<'a>(tokenizer: &mut Tokenizer<'a>) -> Token<'a> {
     if tokenizer.has_at_least(1) && tokenizer.next_char() == '.'
             && matches!(tokenizer.char_at(1), '0'...'9') {
         is_integer = false;
-        tokenizer.advance(1);  // '.' and first digit
+        tokenizer.advance(1);  // Consume '.'
         let mut divisor = 10.;
         while let Some(digit) = tokenizer.next_char().to_digit(10) {
             fractional_part += digit as f64 / divisor;
@@ -757,8 +757,7 @@ fn consume_numeric<'a>(tokenizer: &mut Tokenizer<'a>) -> Token<'a> {
     };
     if is_ident_start(tokenizer) {
         Dimension(value, consume_name(tokenizer))
-    }
-    else {
+    } else {
         Number(value)
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -162,10 +162,10 @@ pub enum Token<'a> {
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub struct NumericValue {
     /// The value as a float
-    pub value: f64,
+    pub value: f32,
 
     /// If the origin source did not include a fractional part, the value as an integer.
-    pub int_value: Option<i64>,
+    pub int_value: Option<i32>,
 
     /// Whether the number had a `+` or `-` sign.
     ///
@@ -178,10 +178,10 @@ pub struct NumericValue {
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub struct PercentageValue {
     /// The value as a float, divided by 100 so that the nominal range is 0.0 to 1.0.
-    pub unit_value: f64,
+    pub unit_value: f32,
 
     /// If the origin source did not include a fractional part, the value as an integer. It is **not** divided by 100.
-    pub int_value: Option<i64>,
+    pub int_value: Option<i32>,
 
     /// Whether the number had a `+` or `-` sign.
     pub signed: bool,
@@ -685,8 +685,8 @@ fn consume_numeric<'a>(tokenizer: &mut Tokenizer<'a>) -> Token<'a> {
             repr = &repr[1..]
         }
         // TODO: handle overflow
-        (repr.parse::<f64>().unwrap(), if is_integer {
-            Some(repr.parse::<i64>().unwrap())
+        (repr.parse::<f32>().unwrap(), if is_integer {
+            Some(repr.parse::<i32>().unwrap())
         } else {
             None
         })

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -170,7 +170,7 @@ pub struct NumericValue {
     /// Whether the number had a `+` or `-` sign.
     ///
     /// This is used is some cases like the <An+B> micro syntax. (See the `parse_nth` function.)
-    pub signed: bool,
+    pub has_sign: bool,
 }
 
 
@@ -184,7 +184,7 @@ pub struct PercentageValue {
     pub int_value: Option<i32>,
 
     /// Whether the number had a `+` or `-` sign.
-    pub signed: bool,
+    pub has_sign: bool,
 }
 
 
@@ -653,8 +653,8 @@ fn consume_numeric<'a>(tokenizer: &mut Tokenizer<'a>) -> Token<'a> {
     // But this is always called so that there is at least one digit in \d*(\.\d+)?
     let start_pos = tokenizer.position();
     let mut is_integer = true;
-    let signed = matches!(tokenizer.next_char(), '-' | '+');
-    if signed {
+    let has_sign = matches!(tokenizer.next_char(), '-' | '+');
+    if has_sign {
         tokenizer.advance(1);
     }
     consume_digits(tokenizer);
@@ -696,13 +696,13 @@ fn consume_numeric<'a>(tokenizer: &mut Tokenizer<'a>) -> Token<'a> {
         return Percentage(PercentageValue {
             unit_value: value / 100.,
             int_value: int_value,
-            signed: signed,
+            has_sign: has_sign,
         })
     }
     let value = NumericValue {
         value: value,
         int_value: int_value,
-        signed: signed,
+        has_sign: has_sign,
     };
     if is_ident_start(tokenizer) { Dimension(value, consume_name(tokenizer)) }
     else { Number(value) }


### PR DESCRIPTION
r? @jdm

This also changes the numeric types in tokens from `f64` / `i64` to `f32` / `i32`, which might requires some changes in Servo.