### PR TITLE
Allow colors to be serialized with `serde`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,16 @@ license = "MPL-2.0"
 rustc-serialize = "0.3"
 tempdir = "0.3"
 
+[dependencies.serde]
+optional = true
+
+[dependencies.serde_macros]
+optional = true
 
 [dependencies]
 encoding = "0.2"
 matches = "0.1"
+
+[features]
+serde-serialization = [ "serde", "serde_macros" ]
+

--- a/src/color.rs
+++ b/src/color.rs
@@ -10,6 +10,7 @@ use super::{Token, Parser, ToCss};
 
 /// A color with red, green, blue, and alpha components.
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde-serialization", derive(Deserialize, Serialize))]
 pub struct RGBA {
     /// The red channel. Nominally in 0.0 ... 1.0.
     pub red: f32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 #![crate_type = "rlib"]
 
 #![deny(missing_docs)]
+#![cfg_attr(feature = "serde-serialization", feature(custom_derive))]
+#![cfg_attr(feature = "serde-serialization", feature(plugin))]
+#![cfg_attr(feature = "serde-serialization", plugin(serde_macros))]
 
 /*!
 
@@ -67,6 +70,7 @@ extern crate encoding;
 #[macro_use] extern crate matches;
 #[cfg(test)] extern crate tempdir;
 #[cfg(test)] extern crate rustc_serialize;
+#[cfg(feature = "serde-serialization")] extern crate serde;
 
 pub use tokenizer::{Token, NumericValue, PercentageValue, SourceLocation};
 pub use rules_and_declarations::{parse_important};


### PR DESCRIPTION
`serde` is an optional Cargo feature.

r? @SimonSapin 