### PR TITLE
Add "token serialization types".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cssparser"
-version = "0.3.8"
+version = "0.3.9"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub use rules_and_declarations::{AtRuleType, QualifiedRuleParser, AtRuleParser};
 pub use from_bytes::decode_stylesheet_bytes;
 pub use color::{RGBA, Color, parse_color_keyword};
 pub use nth::parse_nth;
-pub use serializer::{ToCss, CssStringWriter, serialize_identifier, serialize_string};
+pub use serializer::{ToCss, CssStringWriter, serialize_identifier, serialize_string, TokenSerializationType};
 pub use parser::{Parser, Delimiter, Delimiters, SourcePosition};
 
 


### PR DESCRIPTION
Servo will use this for custom property values which are conceptually sequences of tokens, but are represented in memory as strings. When concatenating such strings, an empty comment `/**/` sometimes needs to be inserted so that two tokens are not reparsed as one.

r? @pcwalton

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/89)
<!-- Reviewable:end -->
