### PR TITLE
Treat url(<string>) as a normal functions, per spec change.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cssparser"
-version = "0.3.9"
+version = "0.4.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -121,7 +121,7 @@ impl<'a> ToCss for Token<'a> {
                     if truncated_start != 0 {
                         try!(write!(dest, "{:X}", truncated_start));
                     }
-                    for _ in (0..question_marks) {
+                    for _ in 0..question_marks {
                         try!(dest.write_str("?"));
                     }
                 } else {


### PR DESCRIPTION
Only unquoted URLs are special tokens now. Use `Parser::expect_url`.

This is a [breaking-change]. The version number was incremented accordingly.

This change will help with https://github.com/servo/servo/issues/7767

This triggers https://github.com/rust-lang/rust/issues/28934 and fails to build in the current Rust nightly, but works fine in the Rust version that Servo currently use. Hopefully that rustc bug will be fixed before we need to upgrade Rust in Servo.

r? @mbrubeck

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/90)
<!-- Reviewable:end -->
