### PR TITLE
Make match_ignore_ascii_case! future-proof.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cssparser"
-version = "0.4.0"
+version = "0.5.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/color.rs
+++ b/src/color.rs
@@ -258,7 +258,7 @@ pub fn parse_color_keyword(ident: &str) -> Result<Color, ()> {
         "yellowgreen" => rgb(154., 205., 50.),
 
         "transparent" => Ok(Color::RGBA(RGBA { red: 0., green: 0., blue: 0., alpha: 0. })),
-        "currentcolor" => Ok(Color::CurrentColor)
+        "currentcolor" => Ok(Color::CurrentColor),
         _ => Err(())
     }
 }
@@ -312,7 +312,7 @@ fn parse_color_function(name: &str, arguments: &mut Parser) -> Result<Color, ()>
         "rgba" => (true, true),
         "rgb" => (true, false),
         "hsl" => (false, false),
-        "hsla" => (false, true)
+        "hsla" => (false, true),
         _ => return Err(())
     };
 

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -18,7 +18,7 @@ pub fn parse_nth(input: &mut Parser) -> Result<(i32, i32), ()> {
             let a = try!(value.int_value.ok_or(())) as i32;
             match_ignore_ascii_case! { unit,
                 "n" => parse_b(input, a),
-                "n-" => parse_signless_b(input, a, -1)
+                "n-" => parse_signless_b(input, a, -1),
                 _ => Ok((a, try!(parse_n_dash_digits(&*unit))))
             }
         }
@@ -29,7 +29,7 @@ pub fn parse_nth(input: &mut Parser) -> Result<(i32, i32), ()> {
                 "n" => parse_b(input, 1),
                 "-n" => parse_b(input, -1),
                 "n-" => parse_signless_b(input, 1, -1),
-                "-n-" => parse_signless_b(input, -1, -1)
+                "-n-" => parse_signless_b(input, -1, -1),
                 _ => if value.starts_with("-") {
                     Ok((-1, try!(parse_n_dash_digits(&value[1..]))))
                 } else {
@@ -41,7 +41,7 @@ pub fn parse_nth(input: &mut Parser) -> Result<(i32, i32), ()> {
             Token::Ident(value) => {
                 match_ignore_ascii_case! { value,
                     "n" => parse_b(input, 1),
-                    "n-" => parse_signless_b(input, 1, -1)
+                    "n-" => parse_signless_b(input, 1, -1),
                     _ => Ok((1, try!(parse_n_dash_digits(&*value))))
                 }
             }


### PR DESCRIPTION
Change the usage syntax to require a comma on the last non-fallback arm, which is a [breaking-change].

The old definition has started to emit a warning in recent nightlies and is likely to be an error in future versions: https://github.com/rust-lang/rfcs/pull/1384

The new definition is recursive to resolve ambiguities. Unfortunately this makes error reporting terrible: https://github.com/rust-lang/rust/issues/31022

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/91)
<!-- Reviewable:end -->
