### PR TITLE
Specify versions for serde and serde_macros (fixes #94)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cssparser"
-version = "0.5.1"
+version = "0.5.2"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"
@@ -17,9 +17,11 @@ rustc-serialize = "0.3"
 tempdir = "0.3"
 
 [dependencies.serde]
+version = "0.6.6"
 optional = true
 
 [dependencies.serde_macros]
+version = "0.6.5"
 optional = true
 
 [dependencies.heapsize]


### PR DESCRIPTION
I just used the versions currently found in Servo.

Fixes #94.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/95)
<!-- Reviewable:end -->
