### PR TITLE
Remove the first rule if it’s `@charset` in "parse a stylesheet"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cssparser"
-version = "0.5.7"
+version = "0.5.8"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/css-parsing-tests/rule_list.json
+++ b/src/css-parsing-tests/rule_list.json
@@ -6,6 +6,11 @@
 
 "@foo", [["at-rule", "foo", [], null]],
 
+"@charset; @foo", [
+    ["at-rule", "charset", [], null],
+    ["at-rule", "foo", [], null]
+],
+
 "@foo bar; \t/* comment */", [["at-rule", "foo", [" ", ["ident", "bar"]], null]],
 
 " /**/ @foo bar{[(4", [["at-rule", "foo",

--- a/src/css-parsing-tests/stylesheet.json
+++ b/src/css-parsing-tests/stylesheet.json
@@ -6,6 +6,13 @@
 
 "@foo", [["at-rule", "foo", [], null]],
 
+"@charset 4 {} @foo", [["at-rule", "foo", [], null]],
+
+"@foo; @charset 4 {}", [
+    ["at-rule", "foo", [], null],
+    ["at-rule", "charset", [" ", ["number", "4", 4, "integer"], " "], []]
+],
+
 "@foo bar; \t/* comment */", [["at-rule", "foo", [" ", ["ident", "bar"]], null]],
 
 " /**/ @foo bar{[(4", [["at-rule", "foo",

--- a/src/css-parsing-tests/stylesheet_bytes.json
+++ b/src/css-parsing-tests/stylesheet_bytes.json
@@ -41,32 +41,27 @@
 
 
 {"css_bytes": "@charset \"ISO-8859-5\"; @\u00E9"},
-[[["at-rule", "charset", [" ", ["string", "ISO-8859-5"]], null],
-  ["at-rule", "щ", [], null]],
+[[["at-rule", "щ", [], null]],
  "iso-8859-5"],
 
 {"css_bytes": "@Charset \"ISO-8859-5\"; @\u00E9",
  "comment": "@charset has to match an exact byte pattern"},
-[[["at-rule", "Charset", [" ", ["string", "ISO-8859-5"]], null],
-  ["at-rule", "�", [], null]],
+[[["at-rule", "�", [], null]],
  "utf-8"],
 
 {"css_bytes": "@charset  \"ISO-8859-5\"; @\u00E9",
  "comment": "@charset has to match an exact byte pattern"},
-[[["at-rule", "charset", [" ", ["string", "ISO-8859-5"]], null],
-  ["at-rule", "�", [], null]],
+[[["at-rule", "�", [], null]],
  "utf-8"],
 
 {"css_bytes": "@charset 'ISO-8859-5'; @\u00E9",
  "comment": "@charset has to match an exact byte pattern"},
-[[["at-rule", "charset", [" ", ["string", "ISO-8859-5"]], null],
-  ["at-rule", "�", [], null]],
+[[["at-rule", "�", [], null]],
  "utf-8"],
 
 {"css_bytes": "@charset \"ISO-8859-5\" ; @\u00E9",
  "comment": "@charset has to match an exact byte pattern"},
-[[["at-rule", "charset", [" ", ["string", "ISO-8859-5"], " "], null],
-  ["at-rule", "�", [], null]],
+[[["at-rule", "�", [], null]],
  "utf-8"],
 
 
@@ -79,35 +74,30 @@
 
 {"css_bytes": "@charset \"UTF-16LE\"; @\u00C3\u00A9",
  "comment": "@charset can only specify ASCII-compatible encodings"},
-[[["at-rule", "charset", [" ", ["string", "UTF-16LE"]], null],
-  ["at-rule", "é", [], null]],
+[[["at-rule", "é", [], null]],
  "utf-8"],
 
 
 {"css_bytes": "\u00EF\u00BB\u00BF @charset \"ISO-8859-5\"; @\u00E9",
  "comment": "BOM takes precedence over @charset"},
-[[["at-rule", "charset", [" ", ["string", "ISO-8859-5"]], null],
-  ["at-rule", "�", [], null]],
+[[["at-rule", "�", [], null]],
  "utf-8"],
 
 {"css_bytes": "\u00EF\u00BB\u00BF @charset \"ISO-8859-5\"; @\u00C3\u00A9",
  "comment": "BOM takes precedence over @charset"},
-[[["at-rule", "charset", [" ", ["string", "ISO-8859-5"]], null],
-  ["at-rule", "é", [], null]],
+[[["at-rule", "é", [], null]],
  "utf-8"],
 
 {"css_bytes": "@charset \"ISO-8859-5\"; @\u00E9",
  "protocol_encoding": " Iso-8859-2",
  "comment": "Protocol takes precedence over @charset"},
-[[["at-rule", "charset", [" ", ["string", "ISO-8859-5"]], null],
-  ["at-rule", "é", [], null]],
+[[["at-rule", "é", [], null]],
  "iso-8859-2"],
 
 {"css_bytes": "@charset \"ISO-8859-5\"; @\u00E9",
  "protocol_encoding": "kamoulox",
  "comment": "Unknow protocol encoding falls back to @charset"},
-[[["at-rule", "charset", [" ", ["string", "ISO-8859-5"]], null],
-  ["at-rule", "щ", [], null]],
+[[["at-rule", "щ", [], null]],
  "iso-8859-5"],
 
 
@@ -120,15 +110,13 @@
 {"css_bytes": "@charset \"ISO-8859-5\"; @\u00E9",
  "environment_encoding": "ISO-8859-2",
  "comment": "@character takes precedence over environment"},
-[[["at-rule", "charset", [" ", ["string", "ISO-8859-5"]], null],
-  ["at-rule", "щ", [], null]],
+[[["at-rule", "щ", [], null]],
  "iso-8859-5"],
 
 {"css_bytes": "@charset \"kamoulox\"; @\u00E9",
  "environment_encoding": "ISO-8859-2",
  "comment": "@character with unknown encoding falls back to environment encoding"},
-[[["at-rule", "charset", [" ", ["string", "kamoulox"]], null],
-  ["at-rule", "é", [], null]],
+[[["at-rule", "é", [], null]],
  "iso-8859-2"],
 
 {"css_bytes": "@\u00E9",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -471,6 +471,9 @@ impl<'i, 't> Parser<'i, 't> {
         if next_byte.is_some() && !self.stop_before.contains(Delimiters::from_byte(next_byte)) {
             debug_assert!(delimiters.contains(Delimiters::from_byte(next_byte)));
             self.tokenizer.advance(1);
+            if next_byte == Some(b'{') {
+                consume_until_end_of_block(BlockType::CurlyBracket, &mut *self.tokenizer);
+            }
         }
         result
     }


### PR DESCRIPTION
Per spec change https://drafts.csswg.org/css-syntax/#parse-stylesheet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/107)
<!-- Reviewable:end -->
