### PR TITLE
Preconvert in Color::parse to avoid codesize impact

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -135,7 +135,8 @@ fn rgba(red: f32, green: f32, blue: f32, alpha: f32) -> Result<Color, ()> {
 /// (For example, the value of an `Ident` token is fine.)
 #[inline]
 pub fn parse_color_keyword(ident: &str) -> Result<Color, ()> {
-    match_ignore_ascii_case! { ident,
+    use std::ascii::AsciiExt;
+    match &*ident.to_ascii_lowercase() {
         "black" => rgb(0., 0., 0.),
         "silver" => rgb(192., 192., 192.),
         "gray" => rgb(128., 128., 128.),


### PR DESCRIPTION
Do not land.

We currently ascii-lowercase each time. We shouldn't do that in large matches.


We should probably have a COW-returning method instead of an unconditional allocation here; so that we retain the speed of not allocating in the common case.



cc @mbrubeck does this improve codesize?

r? @SimonSapin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/115)
<!-- Reviewable:end -->
