### PR TITLE
Character between U+0001 ~ U+001F in string should be escaped when serialized

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -257,8 +257,8 @@ impl<'a, W> fmt::Write for CssStringWriter<'a, W> where W: fmt::Write {
                 b'\n' => "\\A ",
                 b'\r' => "\\D ",
                 b'\0' => "\u{FFFD}",
-                x if (x >= b'\x01' && x <= b'\x1F') || x == b'\x7F' => {
-                    string = format!("\\{:x} ", x);
+                b'\x01'...b'\x1F' | b'\x7F' => {
+                    string = format!("\\{:x} ", b);
                     &string
                 },
                 _ => continue,


### PR DESCRIPTION
Fixes [servo/servo#15947](https://github.com/servo/servo/issues/15947)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/129)
<!-- Reviewable:end -->
