### PR TITLE
Stop using temp files and an external program for diffs in test failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["src/css-parsing-tests"]
 
 [dev-dependencies]
 rustc-serialize = "0.3"
-tempdir = "0.3"
+difference = "1.0"
 encoding_rs = "0.5"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ fn parse_border_spacing(_context: &ParserContext, input: &mut Parser)
 #[macro_use] extern crate procedural_masquerade;
 #[doc(hidden)] pub extern crate phf as _internal__phf;
 #[cfg(test)] extern crate encoding_rs;
-#[cfg(test)] extern crate tempdir;
+#[cfg(test)] extern crate difference;
 #[cfg(test)] extern crate rustc_serialize;
 #[cfg(feature = "serde")] extern crate serde;
 #[cfg(feature = "heapsize")] #[macro_use] extern crate heapsize;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,12 +7,7 @@ extern crate test;
 
 use encoding_rs;
 use std::borrow::Cow::{self, Borrowed};
-use std::fs::File;
-use std::io::{self, Write};
-use std::path::Path;
-use std::process::Command;
 use rustc_serialize::json::{self, Json, ToJson};
-use tempdir::TempDir;
 
 #[cfg(feature = "bench")]
 use self::test::Bencher;
@@ -29,29 +24,6 @@ macro_rules! JArray {
     ($($e: expr,)*) => { JArray![ $( $e ),* ] };
     ($($e: expr),*) => { Json::Array(vec!( $( $e.to_json() ),* )) }
 }
-
-
-fn write_whole_file(path: &Path, data: &str) -> io::Result<()> {
-    (try!(File::create(path))).write_all(data.as_bytes())
-}
-
-
-fn print_json_diff(results: &Json, expected: &Json) -> io::Result<()> {
-    let temp = try!(TempDir::new("rust-cssparser-tests"));
-    let results = results.pretty().to_string() + "\n";
-    let expected = expected.pretty().to_string() + "\n";
-    let result_path = temp.path().join("results.json");
-    let expected_path = temp.path().join("expected.json");
-    try!(write_whole_file(&result_path, &results));
-    try!(write_whole_file(&expected_path, &expected));
-    try!(Command::new("colordiff")
-        .arg("-u1000")
-        .arg(&result_path)
-        .arg(&expected_path)
-        .status());
-    Ok(())
-}
-
 
 fn almost_equals(a: &Json, b: &Json) -> bool {
     match (a, b) {
@@ -93,7 +65,11 @@ fn normalize(json: &mut Json) {
 fn assert_json_eq(results: json::Json, mut expected: json::Json, message: String) {
     normalize(&mut expected);
     if !almost_equals(&results, &expected) {
-        print_json_diff(&results, &expected).unwrap();
+        println!("{}", ::difference::Changeset::new(
+            &results.pretty().to_string(),
+            &expected.pretty().to_string(),
+            "\n",
+        ));
         panic!(message)
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/130)
<!-- Reviewable:end -->
