### PR TITLE
Mark invalid Rust as text-only documentation.

### DIFF
--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -62,7 +62,7 @@ define_proc_macros! {
     /// and the corresponding value as a const expression.
     ///
     /// Output: a rust-phf map, with keys ASCII-lowercased:
-    /// ```
+    /// ```text
     /// static MAP: &'static ::cssparser::phf::Map<&'static str, $ValueType> = …;
     /// ```
     #[allow(non_snake_case)]


### PR DESCRIPTION
This avoids https://github.com/rust-lang/rust/issues/40978.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/131)
<!-- Reviewable:end -->
