### PR TITLE
Numeric faster

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -632,6 +632,18 @@ fn unquoted_url(b: &mut Bencher) {
     })
 }
 
+
+#[cfg(feature = "bench")]
+#[bench]
+fn numeric(b: &mut Bencher) {
+    b.iter(|| {
+        for _ in 0..1000000 {
+            let mut input = Parser::new("10px");
+            let _ = test::black_box(input.next());
+        }
+    })
+}
+
 struct JsonParser;
 
 #[test]


### PR DESCRIPTION
The following commit:

 * Removes char logic from consume_numeric.
 * Rearranges exponent parsing to look at one char in the common case
   (presumably not a big deal).

This makes the benchmark added in the first commit go from:

  test tests::numeric      ... bench:  48,221,308 ns/iter (+/- 3,356,881)

to:

  test tests::numeric      ... bench:  43,656,802 ns/iter (+/- 1,323,570)

on my machine.

Which is pretty much a micro-optimization, but perhaps it's worth given how
common these values are.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/132)
<!-- Reviewable:end -->
