### PR TITLE
Return more specific errors from parsing APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cssparser"
-version = "0.13.5"
+version = "0.14.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/color.rs
+++ b/src/color.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 use std::f32::consts::PI;
 
-use super::{Token, Parser, ToCss};
+use super::{Token, Parser, ToCss, ParseError};
 use tokenizer::NumericValue;
 
 #[cfg(feature = "serde")]
@@ -141,46 +141,47 @@ impl Color {
     /// Parse a <color> value, per CSS Color Module Level 3.
     ///
     /// FIXME(#2) Deprecated CSS2 System Colors are not supported yet.
-    pub fn parse(input: &mut Parser) -> Result<Color, ()> {
-        match try!(input.next()) {
-            Token::Hash(value) | Token::IDHash(value) => {
+    pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Color, ParseError<'i>> {
+        let token = try!(input.next());
+        match token {
+            Token::Hash(ref value) | Token::IDHash(ref value) => {
                 Color::parse_hash(value.as_bytes())
             },
-            Token::Ident(value) => parse_color_keyword(&*value),
-            Token::Function(name) => {
-                input.parse_nested_block(|arguments| {
+            Token::Ident(ref value) => parse_color_keyword(&*value),
+            Token::Function(ref name) => {
+                return input.parse_nested_block(|arguments| {
                     parse_color_function(&*name, arguments)
-                })
+                });
             }
             _ => Err(())
-        }
+        }.map_err(|()| ParseError::UnexpectedToken(token))
     }
 
     /// Parse a color hash, without the leading '#' character.
     #[inline]
     pub fn parse_hash(value: &[u8]) -> Result<Self, ()> {
         match value.len() {
-            8 => rgba(
+            8 => Ok(rgba(
                 try!(from_hex(value[0])) * 16 + try!(from_hex(value[1])),
                 try!(from_hex(value[2])) * 16 + try!(from_hex(value[3])),
                 try!(from_hex(value[4])) * 16 + try!(from_hex(value[5])),
-                try!(from_hex(value[6])) * 16 + try!(from_hex(value[7])),
+                try!(from_hex(value[6])) * 16 + try!(from_hex(value[7]))),
             ),
-            6 => rgb(
+            6 => Ok(rgb(
                 try!(from_hex(value[0])) * 16 + try!(from_hex(value[1])),
                 try!(from_hex(value[2])) * 16 + try!(from_hex(value[3])),
-                try!(from_hex(value[4])) * 16 + try!(from_hex(value[5])),
+                try!(from_hex(value[4])) * 16 + try!(from_hex(value[5]))),
             ),
-            4 => rgba(
+            4 => Ok(rgba(
                 try!(from_hex(value[0])) * 17,
                 try!(from_hex(value[1])) * 17,
                 try!(from_hex(value[2])) * 17,
-                try!(from_hex(value[3])) * 17,
+                try!(from_hex(value[3])) * 17),
             ),
-            3 => rgb(
+            3 => Ok(rgb(
                 try!(from_hex(value[0])) * 17,
                 try!(from_hex(value[1])) * 17,
-                try!(from_hex(value[2])) * 17,
+                try!(from_hex(value[2])) * 17),
             ),
             _ => Err(())
         }
@@ -190,13 +191,13 @@ impl Color {
 
 
 #[inline]
-fn rgb(red: u8, green: u8, blue: u8) -> Result<Color, ()> {
+fn rgb(red: u8, green: u8, blue: u8) -> Color {
     rgba(red, green, blue, 255)
 }
 
 #[inline]
-fn rgba(red: u8, green: u8, blue: u8, alpha: u8) -> Result<Color, ()> {
-    Ok(Color::RGBA(RGBA::new(red, green, blue, alpha)))
+fn rgba(red: u8, green: u8, blue: u8, alpha: u8) -> Color {
+    Color::RGBA(RGBA::new(red, green, blue, alpha))
 }
 
 
@@ -410,11 +411,11 @@ fn clamp_floor_256_f32(val: f32) -> u8 {
 }
 
 #[inline]
-fn parse_color_function(name: &str, arguments: &mut Parser) -> Result<Color, ()> {
+fn parse_color_function<'i, 't>(name: &str, arguments: &mut Parser<'i, 't>) -> Result<Color, ParseError<'i>> {
     let (red, green, blue, uses_commas) = match_ignore_ascii_case! { name,
         "rgb" | "rgba" => parse_rgb_components_rgb(arguments)?,
         "hsl" | "hsla" => parse_rgb_components_hsl(arguments)?,
-        _ => return Err(())
+        _ => return Err(ParseError::UnexpectedToken(Token::Ident(name.to_owned().into()))),
     };
 
     let alpha = if !arguments.is_exhausted() {
@@ -423,7 +424,7 @@ fn parse_color_function(name: &str, arguments: &mut Parser) -> Result<Color, ()>
         } else {
             match try!(arguments.next()) {
                 Token::Delim('/') => {},
-                _ => return Err(())
+                t => return Err(ParseError::UnexpectedToken(t)),
             };
         };
         let token = try!(arguments.next());
@@ -434,8 +435,8 @@ fn parse_color_function(name: &str, arguments: &mut Parser) -> Result<Color, ()>
             Token::Percentage(ref v) => {
                 clamp_unit_f32(v.unit_value)
             }
-            _ => {
-                return Err(())
+            t => {
+                return Err(ParseError::UnexpectedToken(t))
             }
         }
     } else {
@@ -443,12 +444,12 @@ fn parse_color_function(name: &str, arguments: &mut Parser) -> Result<Color, ()>
     };
 
     try!(arguments.expect_exhausted());
-    rgba(red, green, blue, alpha)
+    Ok(rgba(red, green, blue, alpha))
 }
 
 
 #[inline]
-fn parse_rgb_components_rgb(arguments: &mut Parser) -> Result<(u8, u8, u8, bool), ()> {
+fn parse_rgb_components_rgb<'i, 't>(arguments: &mut Parser<'i, 't>) -> Result<(u8, u8, u8, bool), ParseError<'i>> {
     let red: u8;
     let green: u8;
     let blue: u8;
@@ -465,7 +466,7 @@ fn parse_rgb_components_rgb(arguments: &mut Parser) -> Result<(u8, u8, u8, bool)
                     uses_commas = true;
                     try!(arguments.expect_number())
                 }
-                _ => return Err(())
+                t => return Err(ParseError::UnexpectedToken(t))
             });
             if uses_commas {
                 try!(arguments.expect_comma());
@@ -480,36 +481,38 @@ fn parse_rgb_components_rgb(arguments: &mut Parser) -> Result<(u8, u8, u8, bool)
                     uses_commas = true;
                     try!(arguments.expect_percentage())
                 }
-                _ => return Err(())
+                t => return Err(ParseError::UnexpectedToken(t))
             });
             if uses_commas {
                 try!(arguments.expect_comma());
             }
             blue = clamp_unit_f32(try!(arguments.expect_percentage()));
         }
-        _ => return Err(())
+        t => return Err(ParseError::UnexpectedToken(t))
     };
     return Ok((red, green, blue, uses_commas));
 }
 
 #[inline]
-fn parse_rgb_components_hsl(arguments: &mut Parser) -> Result<(u8, u8, u8, bool), ()> {
+fn parse_rgb_components_hsl<'i, 't>(arguments: &mut Parser<'i, 't>) -> Result<(u8, u8, u8, bool), ParseError<'i>> {
     let mut uses_commas = false;
     // Hue given as an angle
     // https://drafts.csswg.org/css-values/#angles
-    let hue_degrees = match try!(arguments.next()) {
-        Token::Number(NumericValue { value: v, .. }) => v,
-        Token::Dimension(NumericValue { value: v, .. }, unit) => {
+    let token = try!(arguments.next());
+    let hue_degrees = match token {
+        Token::Number(NumericValue { value: v, .. }) => Ok(v),
+        Token::Dimension(NumericValue { value: v, .. }, ref unit) => {
             match_ignore_ascii_case! { &*unit,
-                "deg" => v,
-                "grad" => v * 360. / 400.,
-                "rad" => v * 360. / (2. * PI),
-                "turn" => v * 360.,
-                _ => return Err(())
+                "deg" => Ok(v),
+                "grad" => Ok(v * 360. / 400.),
+                "rad" => Ok(v * 360. / (2. * PI)),
+                "turn" => Ok(v * 360.),
+                _ => Err(()),
             }
         }
-        _ => return Err(())
+        t => return Err(ParseError::UnexpectedToken(t))
     };
+    let hue_degrees = try!(hue_degrees.map_err(|()| ParseError::UnexpectedToken(token)));
     // Subtract an integer before rounding, to avoid some rounding errors:
     let hue_normalized_degrees = hue_degrees - 360. * (hue_degrees / 360.).floor();
     let hue = hue_normalized_degrees / 360.;
@@ -522,7 +525,7 @@ fn parse_rgb_components_hsl(arguments: &mut Parser) -> Result<(u8, u8, u8, bool)
             uses_commas = true;
             try!(arguments.expect_percentage())
         }
-        _ => return Err(())
+        t => return Err(ParseError::UnexpectedToken(t))
     };
     let saturation = saturation.max(0.).min(1.);
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 use std::f32::consts::PI;
 
-use super::{Token, Parser, ToCss, ParseError};
+use super::{Token, Parser, ToCss, ParseError, BasicParseError};
 use tokenizer::NumericValue;
 
 #[cfg(feature = "serde")]
@@ -141,7 +141,7 @@ impl Color {
     /// Parse a <color> value, per CSS Color Module Level 3.
     ///
     /// FIXME(#2) Deprecated CSS2 System Colors are not supported yet.
-    pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Color, ParseError<'i>> {
+    pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Color, BasicParseError<'i>> {
         let token = try!(input.next());
         match token {
             Token::Hash(ref value) | Token::IDHash(ref value) => {
@@ -151,10 +151,11 @@ impl Color {
             Token::Function(ref name) => {
                 return input.parse_nested_block(|arguments| {
                     parse_color_function(&*name, arguments)
-                });
+                        .map_err(|e| ParseError::Basic(e))
+                }).map_err(ParseError::<()>::basic);
             }
             _ => Err(())
-        }.map_err(|()| ParseError::UnexpectedToken(token))
+        }.map_err(|()| BasicParseError::UnexpectedToken(token))
     }
 
     /// Parse a color hash, without the leading '#' character.
@@ -411,11 +412,11 @@ fn clamp_floor_256_f32(val: f32) -> u8 {
 }
 
 #[inline]
-fn parse_color_function<'i, 't>(name: &str, arguments: &mut Parser<'i, 't>) -> Result<Color, ParseError<'i>> {
+fn parse_color_function<'i, 't>(name: &str, arguments: &mut Parser<'i, 't>) -> Result<Color, BasicParseError<'i>> {
     let (red, green, blue, uses_commas) = match_ignore_ascii_case! { name,
         "rgb" | "rgba" => parse_rgb_components_rgb(arguments)?,
         "hsl" | "hsla" => parse_rgb_components_hsl(arguments)?,
-        _ => return Err(ParseError::UnexpectedToken(Token::Ident(name.to_owned().into()))),
+        _ => return Err(BasicParseError::UnexpectedToken(Token::Ident(name.to_owned().into()))),
     };
 
     let alpha = if !arguments.is_exhausted() {
@@ -424,7 +425,7 @@ fn parse_color_function<'i, 't>(name: &str, arguments: &mut Parser<'i, 't>) -> R
         } else {
             match try!(arguments.next()) {
                 Token::Delim('/') => {},
-                t => return Err(ParseError::UnexpectedToken(t)),
+                t => return Err(BasicParseError::UnexpectedToken(t)),
             };
         };
         let token = try!(arguments.next());
@@ -436,7 +437,7 @@ fn parse_color_function<'i, 't>(name: &str, arguments: &mut Parser<'i, 't>) -> R
                 clamp_unit_f32(v.unit_value)
             }
             t => {
-                return Err(ParseError::UnexpectedToken(t))
+                return Err(BasicParseError::UnexpectedToken(t))
             }
         }
     } else {
@@ -449,7 +450,7 @@ fn parse_color_function<'i, 't>(name: &str, arguments: &mut Parser<'i, 't>) -> R
 
 
 #[inline]
-fn parse_rgb_components_rgb<'i, 't>(arguments: &mut Parser<'i, 't>) -> Result<(u8, u8, u8, bool), ParseError<'i>> {
+fn parse_rgb_components_rgb<'i, 't>(arguments: &mut Parser<'i, 't>) -> Result<(u8, u8, u8, bool), BasicParseError<'i>> {
     let red: u8;
     let green: u8;
     let blue: u8;
@@ -466,7 +467,7 @@ fn parse_rgb_components_rgb<'i, 't>(arguments: &mut Parser<'i, 't>) -> Result<(u
                     uses_commas = true;
                     try!(arguments.expect_number())
                 }
-                t => return Err(ParseError::UnexpectedToken(t))
+                t => return Err(BasicParseError::UnexpectedToken(t))
             });
             if uses_commas {
                 try!(arguments.expect_comma());
@@ -481,20 +482,20 @@ fn parse_rgb_components_rgb<'i, 't>(arguments: &mut Parser<'i, 't>) -> Result<(u
                     uses_commas = true;
                     try!(arguments.expect_percentage())
                 }
-                t => return Err(ParseError::UnexpectedToken(t))
+                t => return Err(BasicParseError::UnexpectedToken(t))
             });
             if uses_commas {
                 try!(arguments.expect_comma());
             }
             blue = clamp_unit_f32(try!(arguments.expect_percentage()));
         }
-        t => return Err(ParseError::UnexpectedToken(t))
+        t => return Err(BasicParseError::UnexpectedToken(t))
     };
     return Ok((red, green, blue, uses_commas));
 }
 
 #[inline]
-fn parse_rgb_components_hsl<'i, 't>(arguments: &mut Parser<'i, 't>) -> Result<(u8, u8, u8, bool), ParseError<'i>> {
+fn parse_rgb_components_hsl<'i, 't>(arguments: &mut Parser<'i, 't>) -> Result<(u8, u8, u8, bool), BasicParseError<'i>> {
     let mut uses_commas = false;
     // Hue given as an angle
     // https://drafts.csswg.org/css-values/#angles
@@ -510,9 +511,9 @@ fn parse_rgb_components_hsl<'i, 't>(arguments: &mut Parser<'i, 't>) -> Result<(u
                 _ => Err(()),
             }
         }
-        t => return Err(ParseError::UnexpectedToken(t))
+        t => return Err(BasicParseError::UnexpectedToken(t))
     };
-    let hue_degrees = try!(hue_degrees.map_err(|()| ParseError::UnexpectedToken(token)));
+    let hue_degrees = try!(hue_degrees.map_err(|()| BasicParseError::UnexpectedToken(token)));
     // Subtract an integer before rounding, to avoid some rounding errors:
     let hue_normalized_degrees = hue_degrees - 360. * (hue_degrees / 360.).floor();
     let hue = hue_normalized_degrees / 360.;
@@ -525,7 +526,7 @@ fn parse_rgb_components_hsl<'i, 't>(arguments: &mut Parser<'i, 't>) -> Result<(u
             uses_commas = true;
             try!(arguments.expect_percentage())
         }
-        t => return Err(ParseError::UnexpectedToken(t))
+        t => return Err(BasicParseError::UnexpectedToken(t))
     };
     let saturation = saturation.max(0.).min(1.);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub use from_bytes::{stylesheet_encoding, EncodingSupport};
 pub use color::{RGBA, Color, parse_color_keyword};
 pub use nth::parse_nth;
 pub use serializer::{ToCss, CssStringWriter, serialize_identifier, serialize_string, TokenSerializationType};
-pub use parser::{Parser, Delimiter, Delimiters, SourcePosition};
+pub use parser::{Parser, Delimiter, Delimiters, SourcePosition, ParseError};
 pub use unicode_range::UnicodeRange;
 
 // For macros

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub use from_bytes::{stylesheet_encoding, EncodingSupport};
 pub use color::{RGBA, Color, parse_color_keyword};
 pub use nth::parse_nth;
 pub use serializer::{ToCss, CssStringWriter, serialize_identifier, serialize_string, TokenSerializationType};
-pub use parser::{Parser, Delimiter, Delimiters, SourcePosition, ParseError};
+pub use parser::{Parser, Delimiter, Delimiters, SourcePosition, ParseError, BasicParseError};
 pub use unicode_range::UnicodeRange;
 
 // For macros

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -4,76 +4,98 @@
 
 use std::ascii::AsciiExt;
 
-use super::{Token, Parser};
+use super::{Token, Parser, ParseError};
 
 
 /// Parse the *An+B* notation, as found in the `:nth-child()` selector.
 /// The input is typically the arguments of a function,
 /// in which case the caller needs to check if the arguments’ parser is exhausted.
 /// Return `Ok((A, B))`, or `Err(())` for a syntax error.
-pub fn parse_nth(input: &mut Parser) -> Result<(i32, i32), ()> {
-    match try!(input.next()) {
-        Token::Number(value) => Ok((0, try!(value.int_value.ok_or(())) as i32)),
-        Token::Dimension(value, unit) => {
-            let a = try!(value.int_value.ok_or(())) as i32;
-            match_ignore_ascii_case! { &unit,
-                "n" => parse_b(input, a),
-                "n-" => parse_signless_b(input, a, -1),
-                _ => Ok((a, try!(parse_n_dash_digits(&*unit))))
+pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), ParseError<'i>> {
+    let token = try!(input.next());
+    match token {
+        Token::Number(ref value) => {
+            match value.int_value {
+                Some(v) => Ok((0, v as i32)),
+                None => Err(()),
             }
         }
-        Token::Ident(value) => {
+        Token::Dimension(value, ref unit) => {
+            match value.int_value {
+                Some(v) => {
+                    let a = v as i32;
+                    match_ignore_ascii_case! {
+                        &unit,
+                        "n" => Ok(try!(parse_b(input, a))),
+                        "n-" => Ok(try!(parse_signless_b(input, a, -1))),
+                        _ => {
+                            parse_n_dash_digits(&*unit).map(|val| (a, val))
+                        }
+                    }
+                }
+                None => Err(()),
+            }
+        }
+        Token::Ident(ref value) => {
             match_ignore_ascii_case! { &value,
                 "even" => Ok((2, 0)),
                 "odd" => Ok((2, 1)),
-                "n" => parse_b(input, 1),
-                "-n" => parse_b(input, -1),
-                "n-" => parse_signless_b(input, 1, -1),
-                "-n-" => parse_signless_b(input, -1, -1),
+                "n" => Ok(try!(parse_b(input, 1))),
+                "-n" => Ok(try!(parse_b(input, -1))),
+                "n-" => Ok(try!(parse_signless_b(input, 1, -1))),
+                "-n-" => Ok(try!(parse_signless_b(input, -1, -1))),
                 _ => if value.starts_with("-") {
-                    Ok((-1, try!(parse_n_dash_digits(&value[1..]))))
+                    parse_n_dash_digits(&value[1..]).map(|v| (-1, v))
                 } else {
-                    Ok((1, try!(parse_n_dash_digits(&*value))))
+                    parse_n_dash_digits(&*value).map(|v| (1, v))
                 }
             }
         }
         Token::Delim('+') => match try!(input.next_including_whitespace()) {
             Token::Ident(value) => {
                 match_ignore_ascii_case! { &value,
-                    "n" => parse_b(input, 1),
-                    "n-" => parse_signless_b(input, 1, -1),
-                    _ => Ok((1, try!(parse_n_dash_digits(&*value))))
+                    "n" => Ok(try!(parse_b(input, 1))),
+                    "n-" => Ok(try!(parse_signless_b(input, 1, -1))),
+                    _ => parse_n_dash_digits(&*value).map(|v| (1, v))
                 }
             }
-            _ => Err(())
+            t => return Err(ParseError::UnexpectedToken(t)),
         },
-        _ => Err(())
-    }
+        _ => Err(()),
+    }.map_err(|()| ParseError::UnexpectedToken(token))
 }
 
 
-fn parse_b(input: &mut Parser, a: i32) -> Result<(i32, i32), ()> {
+fn parse_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32) -> Result<(i32, i32), ParseError<'i>> {
     let start_position = input.position();
-    match input.next() {
-        Ok(Token::Delim('+')) => parse_signless_b(input, a, 1),
-        Ok(Token::Delim('-')) => parse_signless_b(input, a, -1),
+    let token = input.next();
+    match token {
+        Ok(Token::Delim('+')) => Ok(try!(parse_signless_b(input, a, 1))),
+        Ok(Token::Delim('-')) => Ok(try!(parse_signless_b(input, a, -1))),
         Ok(Token::Number(ref value)) if value.has_sign => {
-            Ok((a, try!(value.int_value.ok_or(())) as i32))
+            match value.int_value {
+                Some(v) => Ok((a, v as i32)),
+                None => Err(()),
+            }
         }
         _ => {
             input.reset(start_position);
             Ok((a, 0))
         }
-    }
+    }.map_err(|()| ParseError::UnexpectedToken(token.unwrap()))
 }
 
-fn parse_signless_b(input: &mut Parser, a: i32, b_sign: i32) -> Result<(i32, i32), ()> {
-    match try!(input.next()) {
+fn parse_signless_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32, b_sign: i32) -> Result<(i32, i32), ParseError<'i>> {
+    let token = try!(input.next());
+    match token {
         Token::Number(ref value) if !value.has_sign => {
-            Ok((a, b_sign * (try!(value.int_value.ok_or(())) as i32)))
+            match value.int_value {
+                Some(v) => Ok((a, b_sign * v as i32)),
+                None => Err(()),
+            }
         }
         _ => Err(())
-    }
+    }.map_err(|()| ParseError::UnexpectedToken(token))
 }
 
 fn parse_n_dash_digits(string: &str) -> Result<i32, ()> {

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -4,14 +4,14 @@
 
 use std::ascii::AsciiExt;
 
-use super::{Token, Parser, ParseError};
+use super::{Token, Parser, BasicParseError};
 
 
 /// Parse the *An+B* notation, as found in the `:nth-child()` selector.
 /// The input is typically the arguments of a function,
 /// in which case the caller needs to check if the arguments’ parser is exhausted.
 /// Return `Ok((A, B))`, or `Err(())` for a syntax error.
-pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), ParseError<'i>> {
+pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), BasicParseError<'i>> {
     let token = try!(input.next());
     match token {
         Token::Number(ref value) => {
@@ -59,14 +59,14 @@ pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), Parse
                     _ => parse_n_dash_digits(&*value).map(|v| (1, v))
                 }
             }
-            t => return Err(ParseError::UnexpectedToken(t)),
+            t => return Err(BasicParseError::UnexpectedToken(t)),
         },
         _ => Err(()),
-    }.map_err(|()| ParseError::UnexpectedToken(token))
+    }.map_err(|()| BasicParseError::UnexpectedToken(token))
 }
 
 
-fn parse_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32) -> Result<(i32, i32), ParseError<'i>> {
+fn parse_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32) -> Result<(i32, i32), BasicParseError<'i>> {
     let start_position = input.position();
     let token = input.next();
     match token {
@@ -82,10 +82,10 @@ fn parse_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32) -> Result<(i32, i32), Par
             input.reset(start_position);
             Ok((a, 0))
         }
-    }.map_err(|()| ParseError::UnexpectedToken(token.unwrap()))
+    }.map_err(|()| BasicParseError::UnexpectedToken(token.unwrap()))
 }
 
-fn parse_signless_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32, b_sign: i32) -> Result<(i32, i32), ParseError<'i>> {
+fn parse_signless_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32, b_sign: i32) -> Result<(i32, i32), BasicParseError<'i>> {
     let token = try!(input.next());
     match token {
         Token::Number(ref value) if !value.has_sign => {
@@ -95,7 +95,7 @@ fn parse_signless_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32, b_sign: i32) -> 
             }
         }
         _ => Err(())
-    }.map_err(|()| ParseError::UnexpectedToken(token))
+    }.map_err(|()| BasicParseError::UnexpectedToken(token))
 }
 
 fn parse_n_dash_digits(string: &str) -> Result<i32, ()> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,15 +21,44 @@ pub struct SourcePosition {
     at_start_of: Option<BlockType>,
 }
 
-///
+/// The funamental parsing errors that can be triggered by built-in parsing routines.
 #[derive(Clone, Debug, PartialEq)]
-pub enum ParseError<'a> {
-    ///
+pub enum BasicParseError<'a> {
+    /// An unexpected token was encountered.
     UnexpectedToken(Token<'a>),
-    ///
+    /// A particular token was expected but not found.
     ExpectedToken(Token<'a>),
-    ///
-    UnexpectedEof,
+    /// The end of the input was encountered unexpectedly.
+    EndOfInput,
+    /// An `@` rule was encountered that was invalid.
+    AtRuleInvalid,
+    /// A qualified rule was encountered that was invalid.
+    QualifiedRuleInvalid,
+}
+
+impl<'a, T> From<BasicParseError<'a>> for ParseError<'a, T> {
+    fn from(this: BasicParseError<'a>) -> ParseError<'a, T> {
+        ParseError::Basic(this)
+    }
+}
+
+/// Extensible parse errors that can be encountered by client parsing implementations.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ParseError<'a, T: 'a> {
+    /// A fundamental parse error from a built-in parsing routine.
+    Basic(BasicParseError<'a>),
+    /// A parse error reported by downstream consumer code.
+    Custom(T),
+}
+
+impl<'a, T> ParseError<'a, T> {
+    /// Extract the fundamental parse error from an extensible error.
+    pub fn basic(self) -> BasicParseError<'a> {
+        match self {
+            ParseError::Basic(e) => e,
+            ParseError::Custom(_) => panic!("Not a basic parse error"),
+        }
+    }
 }
 
 /// Like std::borrow::Cow, except the borrowed variant contains a mutable
@@ -198,11 +227,12 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// This ignores whitespace and comments.
     #[inline]
-    pub fn expect_exhausted(&mut self) -> Result<(), ParseError<'i>> {
+    pub fn expect_exhausted(&mut self) -> Result<(), BasicParseError<'i>> {
         let start_position = self.position();
         let result = match self.next() {
-            Err(_) => Ok(()), //XXXjdm swallowing non-UnexpectedEof errors seems wrong, but tests fail
-            Ok(t) => Err(ParseError::UnexpectedToken(t)),
+            Err(BasicParseError::EndOfInput) => Ok(()),
+            Err(e) => unreachable!("Unexpected error encountered: {:?}", e),
+            Ok(t) => Err(BasicParseError::UnexpectedToken(t)),
         };
         self.reset(start_position);
         result
@@ -306,7 +336,7 @@ impl<'i, 't> Parser<'i, 't> {
     /// See the `Parser::parse_nested_block` method to parse the content of functions or blocks.
     ///
     /// This only returns a closing token when it is unmatched (and therefore an error).
-    pub fn next(&mut self) -> Result<Token<'i>, ParseError<'i>> {
+    pub fn next(&mut self) -> Result<Token<'i>, BasicParseError<'i>> {
         loop {
             match self.next_including_whitespace_and_comments() {
                 Ok(Token::WhiteSpace(_)) | Ok(Token::Comment(_)) => {},
@@ -316,7 +346,7 @@ impl<'i, 't> Parser<'i, 't> {
     }
 
     /// Same as `Parser::next`, but does not skip whitespace tokens.
-    pub fn next_including_whitespace(&mut self) -> Result<Token<'i>, ParseError<'i>> {
+    pub fn next_including_whitespace(&mut self) -> Result<Token<'i>, BasicParseError<'i>> {
         loop {
             match self.next_including_whitespace_and_comments() {
                 Ok(Token::Comment(_)) => {},
@@ -331,15 +361,15 @@ impl<'i, 't> Parser<'i, 't> {
     /// where comments are preserved.
     /// When parsing higher-level values, per the CSS Syntax specification,
     /// comments should always be ignored between tokens.
-    pub fn next_including_whitespace_and_comments(&mut self) -> Result<Token<'i>, ParseError<'i>> {
+    pub fn next_including_whitespace_and_comments(&mut self) -> Result<Token<'i>, BasicParseError<'i>> {
         if let Some(block_type) = self.at_start_of.take() {
             consume_until_end_of_block(block_type, &mut *self.tokenizer);
         }
         let byte = self.tokenizer.next_byte();
         if self.stop_before.contains(Delimiters::from_byte(byte)) {
-            return Err(ParseError::UnexpectedToken(Token::Delim(byte.unwrap_or(0) as char)))
+            return Err(BasicParseError::EndOfInput)
         }
-        let token = try!(self.tokenizer.next().map_err(|()| ParseError::UnexpectedEof));
+        let token = try!(self.tokenizer.next().map_err(|()| BasicParseError::EndOfInput));
         if let Some(block_type) = BlockType::opening(&token) {
             self.at_start_of = Some(block_type);
         }
@@ -351,8 +381,8 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// This can help tell e.g. `color: green;` from `color: green 4px;`
     #[inline]
-    pub fn parse_entirely<F, T>(&mut self, parse: F) -> Result<T, ParseError<'i>>
-    where F: FnOnce(&mut Parser<'i, 't>) -> Result<T, ParseError<'i>> {
+    pub fn parse_entirely<F, T, E>(&mut self, parse: F) -> Result<T, ParseError<'i, E>>
+    where F: FnOnce(&mut Parser<'i, 't>) -> Result<T, ParseError<'i, E>> {
         let result = parse(self);
         try!(self.expect_exhausted());
         result
@@ -369,8 +399,8 @@ impl<'i, 't> Parser<'i, 't> {
     /// This method retuns `Err(())` the first time that a closure call does,
     /// or if a closure call leaves some input before the next comma or the end of the input.
     #[inline]
-    pub fn parse_comma_separated<F, T>(&mut self, mut parse_one: F) -> Result<Vec<T>, ParseError<'i>>
-    where F: for <'ii, 'tt> FnMut(&mut Parser<'ii, 'tt>) -> Result<T, ParseError<'ii>> {
+    pub fn parse_comma_separated<F, T, E>(&mut self, mut parse_one: F) -> Result<Vec<T>, ParseError<'i, E>>
+    where F: for <'ii, 'tt> FnMut(&mut Parser<'ii, 'tt>) -> Result<T, ParseError<'ii, E>> {
         let mut values = vec![];
         loop {
             values.push(try!(self.parse_until_before(Delimiter::Comma, |parser| parse_one(parser))));
@@ -394,8 +424,8 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// The result is overridden to `Err(())` if the closure leaves some input before that point.
     #[inline]
-    pub fn parse_nested_block<F, T>(&mut self, parse: F) -> Result <T, ParseError<'i>>
-    where F: for<'tt> FnOnce(&mut Parser<'i, 'tt>) -> Result<T, ParseError<'i>> {
+    pub fn parse_nested_block<F, T, E>(&mut self, parse: F) -> Result <T, ParseError<'i, E>>
+    where F: for<'tt> FnOnce(&mut Parser<'i, 'tt>) -> Result<T, ParseError<'i, E>> {
         let block_type = self.at_start_of.take().expect("\
             A nested parser can only be created when a Function, \
             ParenthesisBlock, SquareBracketBlock, or CurlyBracketBlock \
@@ -431,9 +461,9 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// The result is overridden to `Err(())` if the closure leaves some input before that point.
     #[inline]
-    pub fn parse_until_before<F, T>(&mut self, delimiters: Delimiters, parse: F)
-                                    -> Result <T, ParseError<'i>>
-    where F: for<'ii, 'tt> FnOnce(&mut Parser<'ii, 'tt>) -> Result<T, ParseError<'ii>> {
+    pub fn parse_until_before<F, T, E>(&mut self, delimiters: Delimiters, parse: F)
+                                    -> Result <T, ParseError<'i, E>>
+    where F: for<'ii, 'tt> FnOnce(&mut Parser<'ii, 'tt>) -> Result<T, ParseError<'ii, E>> {
         let delimiters = self.stop_before | delimiters;
         let result;
         // Introduce a new scope to limit duration of nested_parser’s borrow
@@ -470,9 +500,9 @@ impl<'i, 't> Parser<'i, 't> {
     /// (e.g. if these is only one in the given set)
     /// or if it was there at all (as opposed to reaching the end of the input).
     #[inline]
-    pub fn parse_until_after<F, T>(&mut self, delimiters: Delimiters, parse: F)
-                                   -> Result <T, ParseError<'i>>
-    where F: for<'ii, 'tt> FnOnce(&mut Parser<'ii, 'tt>) -> Result<T, ParseError<'ii>> {
+    pub fn parse_until_after<F, T, E>(&mut self, delimiters: Delimiters, parse: F)
+                                   -> Result <T, ParseError<'i, E>>
+    where F: for<'ii, 'tt> FnOnce(&mut Parser<'ii, 'tt>) -> Result<T, ParseError<'ii, E>> {
         let result = self.parse_until_before(delimiters, parse);
         let next_byte = self.tokenizer.next_byte();
         if next_byte.is_some() && !self.stop_before.contains(Delimiters::from_byte(next_byte)) {
@@ -487,139 +517,142 @@ impl<'i, 't> Parser<'i, 't> {
 
     /// Parse a <whitespace-token> and return its value.
     #[inline]
-    pub fn expect_whitespace(&mut self) -> Result<&'i str, ParseError<'i>> {
+    pub fn expect_whitespace(&mut self) -> Result<&'i str, BasicParseError<'i>> {
         match try!(self.next_including_whitespace()) {
             Token::WhiteSpace(value) => Ok(value),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse a <ident-token> and return the unescaped value.
     #[inline]
-    pub fn expect_ident(&mut self) -> Result<Cow<'i, str>, ParseError<'i>> {
+    pub fn expect_ident(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
         match try!(self.next()) {
             Token::Ident(value) => Ok(value),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse a <ident-token> whose unescaped value is an ASCII-insensitive match for the given value.
     #[inline]
-    pub fn expect_ident_matching(&mut self, expected_value: &str) -> Result<(), ParseError<'i>> {
+    pub fn expect_ident_matching(&mut self, expected_value: &str) -> Result<(), BasicParseError<'i>> {
         match try!(self.next()) {
             Token::Ident(ref value) if value.eq_ignore_ascii_case(expected_value) => Ok(()),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse a <string-token> and return the unescaped value.
     #[inline]
-    pub fn expect_string(&mut self) -> Result<Cow<'i, str>, ParseError<'i>> {
+    pub fn expect_string(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
         match try!(self.next()) {
             Token::QuotedString(value) => Ok(value),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse either a <ident-token> or a <string-token>, and return the unescaped value.
     #[inline]
-    pub fn expect_ident_or_string(&mut self) -> Result<Cow<'i, str>, ParseError<'i>> {
+    pub fn expect_ident_or_string(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
         match try!(self.next()) {
             Token::Ident(value) => Ok(value),
             Token::QuotedString(value) => Ok(value),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse a <url-token> and return the unescaped value.
     #[inline]
-    pub fn expect_url(&mut self) -> Result<Cow<'i, str>, ParseError<'i>> {
+    pub fn expect_url(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
         match try!(self.next()) {
             Token::UnquotedUrl(value) => Ok(value),
             Token::Function(ref name) if name.eq_ignore_ascii_case("url") => {
-                self.parse_nested_block(|input| input.expect_string())
+                self.parse_nested_block(|input| input.expect_string()
+                                        .map_err(|e| ParseError::Basic(e)))
+                    .map_err(ParseError::<()>::basic)
             },
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse either a <url-token> or a <string-token>, and return the unescaped value.
     #[inline]
-    pub fn expect_url_or_string(&mut self) -> Result<Cow<'i, str>, ParseError<'i>> {
+    pub fn expect_url_or_string(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
         match try!(self.next()) {
             Token::UnquotedUrl(value) => Ok(value),
             Token::QuotedString(value) => Ok(value),
             Token::Function(ref name) if name.eq_ignore_ascii_case("url") => {
-                self.parse_nested_block(|input| input.expect_string())
+                self.parse_nested_block(|input| input.expect_string().map_err(|e| ParseError::Basic(e)))
+                    .map_err(ParseError::<()>::basic)
             },
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse a <number-token> and return the integer value.
     #[inline]
-    pub fn expect_number(&mut self) -> Result<f32, ParseError<'i>> {
+    pub fn expect_number(&mut self) -> Result<f32, BasicParseError<'i>> {
         match try!(self.next()) {
             Token::Number(NumericValue { value, .. }) => Ok(value),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse a <number-token> that does not have a fractional part, and return the integer value.
     #[inline]
-    pub fn expect_integer(&mut self) -> Result<i32, ParseError<'i>> {
+    pub fn expect_integer(&mut self) -> Result<i32, BasicParseError<'i>> {
         let token = try!(self.next());
         match token {
-            Token::Number(NumericValue { ref int_value, .. }) if int_value.is_some() => {
-                Ok(int_value.unwrap())
+            Token::Number(NumericValue { int_value: Some(int_value), .. }) => {
+                Ok(int_value)
             }
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse a <percentage-token> and return the value.
     /// `0%` and `100%` map to `0.0` and `1.0` (not `100.0`), respectively.
     #[inline]
-    pub fn expect_percentage(&mut self) -> Result<f32, ParseError<'i>> {
+    pub fn expect_percentage(&mut self) -> Result<f32, BasicParseError<'i>> {
         match try!(self.next()) {
             Token::Percentage(PercentageValue { unit_value, .. }) => Ok(unit_value),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse a `:` <colon-token>.
     #[inline]
-    pub fn expect_colon(&mut self) -> Result<(), ParseError<'i>> {
+    pub fn expect_colon(&mut self) -> Result<(), BasicParseError<'i>> {
         match try!(self.next()) {
             Token::Colon => Ok(()),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse a `;` <semicolon-token>.
     #[inline]
-    pub fn expect_semicolon(&mut self) -> Result<(), ParseError<'i>> {
+    pub fn expect_semicolon(&mut self) -> Result<(), BasicParseError<'i>> {
         match try!(self.next()) {
             Token::Semicolon => Ok(()),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse a `,` <comma-token>.
     #[inline]
-    pub fn expect_comma(&mut self) -> Result<(), ParseError<'i>> {
+    pub fn expect_comma(&mut self) -> Result<(), BasicParseError<'i>> {
         match try!(self.next()) {
             Token::Comma => Ok(()),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
     /// Parse a <delim-token> with the given value.
     #[inline]
-    pub fn expect_delim(&mut self, expected_value: char) -> Result<(), ParseError<'i>> {
+    pub fn expect_delim(&mut self, expected_value: char) -> Result<(), BasicParseError<'i>> {
         match try!(self.next()) {
             Token::Delim(value) if value == expected_value => Ok(()),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
@@ -627,10 +660,10 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// If the result is `Ok`, you can then call the `Parser::parse_nested_block` method.
     #[inline]
-    pub fn expect_curly_bracket_block(&mut self) -> Result<(), ParseError<'i>> {
+    pub fn expect_curly_bracket_block(&mut self) -> Result<(), BasicParseError<'i>> {
         match try!(self.next()) {
             Token::CurlyBracketBlock => Ok(()),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
@@ -638,10 +671,10 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// If the result is `Ok`, you can then call the `Parser::parse_nested_block` method.
     #[inline]
-    pub fn expect_square_bracket_block(&mut self) -> Result<(), ParseError<'i>> {
+    pub fn expect_square_bracket_block(&mut self) -> Result<(), BasicParseError<'i>> {
         match try!(self.next()) {
             Token::SquareBracketBlock => Ok(()),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
@@ -649,10 +682,10 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// If the result is `Ok`, you can then call the `Parser::parse_nested_block` method.
     #[inline]
-    pub fn expect_parenthesis_block(&mut self) -> Result<(), ParseError<'i>> {
+    pub fn expect_parenthesis_block(&mut self) -> Result<(), BasicParseError<'i>> {
         match try!(self.next()) {
             Token::ParenthesisBlock => Ok(()),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
@@ -660,10 +693,10 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// If the result is `Ok`, you can then call the `Parser::parse_nested_block` method.
     #[inline]
-    pub fn expect_function(&mut self) -> Result<Cow<'i, str>, ParseError<'i>> {
+    pub fn expect_function(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
         match try!(self.next()) {
             Token::Function(name) => Ok(name),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
@@ -671,10 +704,10 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// If the result is `Ok`, you can then call the `Parser::parse_nested_block` method.
     #[inline]
-    pub fn expect_function_matching(&mut self, expected_name: &str) -> Result<(), ParseError<'i>> {
+    pub fn expect_function_matching(&mut self, expected_name: &str) -> Result<(), BasicParseError<'i>> {
         match try!(self.next()) {
             Token::Function(ref name) if name.eq_ignore_ascii_case(expected_name) => Ok(()),
-            t => Err(ParseError::UnexpectedToken(t))
+            t => Err(BasicParseError::UnexpectedToken(t))
         }
     }
 
@@ -682,17 +715,19 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// See `Token::is_parse_error`. This also checks nested blocks and functions recursively.
     #[inline]
-    pub fn expect_no_error_token(&mut self) -> Result<(), ParseError<'i>> {
+    pub fn expect_no_error_token(&mut self) -> Result<(), BasicParseError<'i>> {
         loop {
             match self.next_including_whitespace_and_comments() {
                 Ok(Token::Function(_)) | Ok(Token::ParenthesisBlock) |
                 Ok(Token::SquareBracketBlock) | Ok(Token::CurlyBracketBlock) => {
-                    try!(self.parse_nested_block(|input| input.expect_no_error_token()))
+                    let result = self.parse_nested_block(|input| input.expect_no_error_token()
+                                                         .map_err(|e| ParseError::Basic(e)));
+                    try!(result.map_err(ParseError::<()>::basic))
                 }
                 Ok(token) => {
                     if token.is_parse_error() {
-                        //XXXjdm maybe these should be separate variants of ParseError instead?
-                        return Err(ParseError::UnexpectedToken(token))
+                        //FIXME: maybe these should be separate variants of BasicParseError instead?
+                        return Err(BasicParseError::UnexpectedToken(token))
                     }
                 }
                 Err(_) => return Ok(())

--- a/src/rules_and_declarations.rs
+++ b/src/rules_and_declarations.rs
@@ -7,14 +7,14 @@
 use std::ascii::AsciiExt;
 use std::ops::Range;
 use std::borrow::Cow;
-use super::{Token, Parser, Delimiter, SourcePosition, ParseError};
+use super::{Token, Parser, Delimiter, SourcePosition, ParseError, BasicParseError};
 
 
 /// Parse `!important`.
 ///
 /// Typical usage is `input.try(parse_important).is_ok()`
 /// at the end of a `DeclarationParser::parse_value` implementation.
-pub fn parse_important<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), ParseError<'i>> {
+pub fn parse_important<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), BasicParseError<'i>> {
     try!(input.expect_delim('!'));
     input.expect_ident_matching("important")
 }
@@ -52,6 +52,9 @@ pub trait DeclarationParser {
     /// The finished representation of a declaration.
     type Declaration;
 
+    /// The error type that is included in the ParseError value that can be returned.
+    type Error;
+
     /// Parse the value of a declaration with the given `name`.
     ///
     /// Return the finished representation for the declaration
@@ -69,7 +72,8 @@ pub trait DeclarationParser {
     /// If `!important` can be used in a given context,
     /// `input.try(parse_important).is_ok()` should be used at the end
     /// of the implementation of this method and the result should be part of the return value.
-    fn parse_value<'i, 't>(&mut self, name: &str, input: &mut Parser<'i, 't>) -> Result<Self::Declaration, ParseError<'i>>;
+    fn parse_value<'i, 't>(&mut self, name: &str, input: &mut Parser<'i, 't>)
+                           -> Result<Self::Declaration, ParseError<'i, Self::Error>>;
 }
 
 
@@ -89,6 +93,9 @@ pub trait AtRuleParser {
     /// The finished representation of an at-rule.
     type AtRule;
 
+    /// The error type that is included in the ParseError value that can be returned.
+    type Error;
+
     /// Parse the prelude of an at-rule with the given `name`.
     ///
     /// Return the representation of the prelude and the type of at-rule,
@@ -107,10 +114,10 @@ pub trait AtRuleParser {
     /// that ends wherever the prelude should end.
     /// (Before the next semicolon, the next `{`, or the end of the current block.)
     fn parse_prelude<'i, 't>(&mut self, name: &str, input: &mut Parser<'i, 't>)
-                     -> Result<AtRuleType<Self::Prelude, Self::AtRule>, ParseError<'i>> {
+                     -> Result<AtRuleType<Self::Prelude, Self::AtRule>, ParseError<'i, Self::Error>> {
         let _ = name;
         let _ = input;
-        Err(ParseError::UnexpectedEof) //XXXjdm
+        Err(ParseError::Basic(BasicParseError::AtRuleInvalid))
     }
 
     /// Parse the content of a `{ /* ... */ }` block for the body of the at-rule.
@@ -122,10 +129,10 @@ pub trait AtRuleParser {
     /// This is only called when `parse_prelude` returned `WithBlock` or `OptionalBlock`,
     /// and a block was indeed found following the prelude.
     fn parse_block<'i, 't>(&mut self, prelude: Self::Prelude, input: &mut Parser<'i, 't>)
-                   -> Result<Self::AtRule, ParseError<'i>> {
+                   -> Result<Self::AtRule, ParseError<'i, Self::Error>> {
         let _ = prelude;
         let _ = input;
-        Err(ParseError::UnexpectedEof) //XXXjdm
+        Err(ParseError::Basic(BasicParseError::AtRuleInvalid))
     }
 
     /// An `OptionalBlock` prelude was followed by `;`.
@@ -157,6 +164,9 @@ pub trait QualifiedRuleParser {
     /// The finished representation of a qualified rule.
     type QualifiedRule;
 
+    /// The error type that is included in the ParseError value that can be returned.
+    type Error;
+
     /// Parse the prelude of a qualified rule. For style rules, this is as Selector list.
     ///
     /// Return the representation of the prelude,
@@ -166,9 +176,10 @@ pub trait QualifiedRuleParser {
     ///
     /// The given `input` is a "delimited" parser
     /// that ends where the prelude should end (before the next `{`).
-    fn parse_prelude<'i, 't>(&mut self, input: &mut Parser<'i, 't>) -> Result<Self::Prelude, ParseError<'i>> {
+    fn parse_prelude<'i, 't>(&mut self, input: &mut Parser<'i, 't>)
+                             -> Result<Self::Prelude, ParseError<'i, Self::Error>> {
         let _ = input;
-        Err(ParseError::UnexpectedEof) //XXXjdm
+        Err(ParseError::Basic(BasicParseError::QualifiedRuleInvalid))
     }
 
     /// Parse the content of a `{ /* ... */ }` block for the body of the qualified rule.
@@ -177,10 +188,10 @@ pub trait QualifiedRuleParser {
     /// as returned by `RuleListParser::next`,
     /// or `Err(())` to ignore the entire at-rule as invalid.
     fn parse_block<'i, 't>(&mut self, prelude: Self::Prelude, input: &mut Parser<'i, 't>)
-                   -> Result<Self::QualifiedRule, ParseError<'i>> {
+                   -> Result<Self::QualifiedRule, ParseError<'i, Self::Error>> {
         let _ = prelude;
         let _ = input;
-        Err(ParseError::UnexpectedEof) //XXXjdm
+        Err(ParseError::Basic(BasicParseError::QualifiedRuleInvalid))
     }
 }
 
@@ -195,8 +206,8 @@ pub struct DeclarationListParser<'i: 't, 't: 'a, 'a, P> {
 }
 
 
-impl<'i, 't, 'a, I, P> DeclarationListParser<'i, 't, 'a, P>
-where P: DeclarationParser<Declaration = I> + AtRuleParser<AtRule = I> {
+impl<'i, 't, 'a, I, P, E> DeclarationListParser<'i, 't, 'a, P>
+where P: DeclarationParser<Declaration = I, Error = E> + AtRuleParser<AtRule = I, Error = E> {
     /// Create a new `DeclarationListParser` for the given `input` and `parser`.
     ///
     /// Note that all CSS declaration lists can on principle contain at-rules.
@@ -221,11 +232,11 @@ where P: DeclarationParser<Declaration = I> + AtRuleParser<AtRule = I> {
 
 /// `DeclarationListParser` is an iterator that yields `Ok(_)` for a valid declaration or at-rule
 /// or `Err(())` for an invalid one.
-impl<'i, 't, 'a, I, P> Iterator for DeclarationListParser<'i, 't, 'a, P>
-where P: DeclarationParser<Declaration = I> + AtRuleParser<AtRule = I> {
-    type Item = Result<I, PreciseParseError<'i>>;
+impl<'i, 't, 'a, I, P, E: 'i> Iterator for DeclarationListParser<'i, 't, 'a, P>
+where P: DeclarationParser<Declaration = I, Error = E> + AtRuleParser<AtRule = I, Error = E> {
+    type Item = Result<I, PreciseParseError<'i, E>>;
 
-    fn next(&mut self) -> Option<Result<I, PreciseParseError<'i>>> {
+    fn next(&mut self) -> Option<Result<I, PreciseParseError<'i, E>>> {
         loop {
             let start_position = self.input.position();
             match self.input.next_including_whitespace_and_comments() {
@@ -247,7 +258,7 @@ where P: DeclarationParser<Declaration = I> + AtRuleParser<AtRule = I> {
                 }
                 Ok(_) => {
                     return Some(self.input.parse_until_after(Delimiter::Semicolon,
-                                                             |_| Err(ParseError::ExpectedToken(Token::Semicolon)))
+                                                             |_| Err(ParseError::Basic(BasicParseError::ExpectedToken(Token::Semicolon))))
                                 .map_err(|e| PreciseParseError {
                                     error: e,
                                     span: start_position..self.input.position()
@@ -273,8 +284,8 @@ pub struct RuleListParser<'i: 't, 't: 'a, 'a, P> {
 }
 
 
-impl<'i: 't, 't: 'a, 'a, R, P> RuleListParser<'i, 't, 'a, P>
-where P: QualifiedRuleParser<QualifiedRule = R> + AtRuleParser<AtRule = R> {
+impl<'i: 't, 't: 'a, 'a, R, P, E> RuleListParser<'i, 't, 'a, P>
+where P: QualifiedRuleParser<QualifiedRule = R, Error = E> + AtRuleParser<AtRule = R, Error = E> {
     /// Create a new `RuleListParser` for the given `input` at the top-level of a stylesheet
     /// and the given `parser`.
     ///
@@ -313,11 +324,11 @@ where P: QualifiedRuleParser<QualifiedRule = R> + AtRuleParser<AtRule = R> {
 
 
 /// `RuleListParser` is an iterator that yields `Ok(_)` for a rule or `Err(())` for an invalid one.
-impl<'i, 't, 'a, R, P> Iterator for RuleListParser<'i, 't, 'a, P>
-where P: QualifiedRuleParser<QualifiedRule = R> + AtRuleParser<AtRule = R> {
-    type Item = Result<R, PreciseParseError<'i>>;
+impl<'i, 't, 'a, R, P, E: 'i> Iterator for RuleListParser<'i, 't, 'a, P>
+where P: QualifiedRuleParser<QualifiedRule = R, Error = E> + AtRuleParser<AtRule = R, Error = E> {
+    type Item = Result<R, PreciseParseError<'i, E>>;
 
-    fn next(&mut self) -> Option<Result<R, PreciseParseError<'i>>> {
+    fn next(&mut self) -> Option<Result<R, PreciseParseError<'i, E>>> {
         loop {
             let start_position = self.input.position();
             match self.input.next_including_whitespace_and_comments() {
@@ -328,7 +339,7 @@ where P: QualifiedRuleParser<QualifiedRule = R> + AtRuleParser<AtRule = R> {
                     self.any_rule_so_far = true;
                     if first_stylesheet_rule && name.eq_ignore_ascii_case("charset") {
                         let delimiters = Delimiter::Semicolon | Delimiter::CurlyBracketBlock;
-                        let _ = self.input.parse_until_after(delimiters, |_input| Ok(()));
+                        let _: Result<(), ParseError<()>> = self.input.parse_until_after(delimiters, |_| Ok(()));
                     } else {
                         return Some(parse_at_rule(start_position, name, self.input, &mut self.parser))
                     }
@@ -350,10 +361,10 @@ where P: QualifiedRuleParser<QualifiedRule = R> + AtRuleParser<AtRule = R> {
 
 
 /// Parse a single declaration, such as an `( /* ... */ )` parenthesis in an `@supports` prelude.
-pub fn parse_one_declaration<'i, 't, P>(input: &mut Parser<'i, 't>, parser: &mut P)
-                                -> Result<<P as DeclarationParser>::Declaration,
-                                          PreciseParseError<'i>>
-                                where P: DeclarationParser {
+pub fn parse_one_declaration<'i, 't, P, E>(input: &mut Parser<'i, 't>, parser: &mut P)
+                                           -> Result<<P as DeclarationParser>::Declaration,
+                                                     PreciseParseError<'i, E>>
+                                           where P: DeclarationParser<Error = E> {
     let start_position = input.position();
     input.parse_entirely(|input| {
         let name = try!(input.expect_ident());
@@ -367,8 +378,9 @@ pub fn parse_one_declaration<'i, 't, P>(input: &mut Parser<'i, 't>, parser: &mut
 
 
 /// Parse a single rule, such as for CSSOM’s `CSSStyleSheet.insertRule`.
-pub fn parse_one_rule<'i, 't, R, P>(input: &mut Parser<'i, 't>, parser: &mut P) -> Result<R, ParseError<'i>>
-where P: QualifiedRuleParser<QualifiedRule = R> + AtRuleParser<AtRule = R> {
+pub fn parse_one_rule<'i, 't, R, P, E>(input: &mut Parser<'i, 't>, parser: &mut P)
+                                       -> Result<R, ParseError<'i, E>>
+where P: QualifiedRuleParser<QualifiedRule = R, Error = E> + AtRuleParser<AtRule = R, Error = E> {
     input.parse_entirely(|input| {
         loop {
             let start_position = input.position();
@@ -386,15 +398,15 @@ where P: QualifiedRuleParser<QualifiedRule = R> + AtRuleParser<AtRule = R> {
     })
 }
 
-pub struct PreciseParseError<'i> {
-    pub error: ParseError<'i>,
+pub struct PreciseParseError<'i, E: 'i> {
+    pub error: ParseError<'i, E>,
     pub span: Range<SourcePosition>,
 }
 
-fn parse_at_rule<'i, 't, P>(start_position: SourcePosition, name: Cow<str>,
-                            input: &mut Parser<'i, 't>, parser: &mut P)
-                            -> Result<<P as AtRuleParser>::AtRule, PreciseParseError<'i>>
-                            where P: AtRuleParser {
+fn parse_at_rule<'i, 't, P, E>(start_position: SourcePosition, name: Cow<str>,
+                               input: &mut Parser<'i, 't>, parser: &mut P)
+                               -> Result<<P as AtRuleParser>::AtRule, PreciseParseError<'i, E>>
+                               where P: AtRuleParser<Error = E> {
     let delimiters = Delimiter::Semicolon | Delimiter::CurlyBracketBlock;
     let result = input.parse_until_before(delimiters, |input| {
         parser.parse_prelude(&*name, input)
@@ -404,7 +416,7 @@ fn parse_at_rule<'i, 't, P>(start_position: SourcePosition, name: Cow<str>,
             match input.next() {
                 Ok(Token::Semicolon) | Err(_) => Ok(rule),
                 Ok(Token::CurlyBracketBlock) => Err(PreciseParseError {
-                    error: ParseError::UnexpectedToken(Token::CurlyBracketBlock),
+                    error: ParseError::Basic(BasicParseError::UnexpectedToken(Token::CurlyBracketBlock)),
                     span: start_position..input.position(),
                 }),
                 Ok(_) => unreachable!()
@@ -420,11 +432,11 @@ fn parse_at_rule<'i, 't, P>(start_position: SourcePosition, name: Cow<str>,
                         })
                 }
                 Ok(Token::Semicolon) => Err(PreciseParseError {
-                    error: ParseError::UnexpectedToken(Token::Semicolon),
+                    error: ParseError::Basic(BasicParseError::UnexpectedToken(Token::Semicolon)),
                     span: start_position..input.position()
                 }),
                 Err(e) => Err(PreciseParseError {
-                    error: e,
+                    error: ParseError::Basic(e),
                     span: start_position..input.position(),
                 }),
                 Ok(_) => unreachable!()
@@ -434,7 +446,7 @@ fn parse_at_rule<'i, 't, P>(start_position: SourcePosition, name: Cow<str>,
             match input.next() {
                 Ok(Token::Semicolon) | Err(_) => Ok(parser.rule_without_block(prelude)),
                 Ok(Token::CurlyBracketBlock) => {
-                    input.parse_nested_block(/*move*/ |input| parser.parse_block(prelude, input))
+                    input.parse_nested_block(move |input| parser.parse_block(prelude, input))
                         .map_err(|e| PreciseParseError {
                             error: e,
                             span: start_position..input.position(),
@@ -446,13 +458,13 @@ fn parse_at_rule<'i, 't, P>(start_position: SourcePosition, name: Cow<str>,
         Err(_) => {
             let end_position = input.position();
             let error = match input.next() {
-                Ok(Token::CurlyBracketBlock) => ParseError::UnexpectedToken(Token::CurlyBracketBlock),
-                Ok(Token::Semicolon) => ParseError::UnexpectedToken(Token::Semicolon),
+                Ok(Token::CurlyBracketBlock) => BasicParseError::UnexpectedToken(Token::CurlyBracketBlock),
+                Ok(Token::Semicolon) => BasicParseError::UnexpectedToken(Token::Semicolon),
                 Err(e) => e,
                 _ => unreachable!()
             };
             Err(PreciseParseError {
-                error: error,
+                error: ParseError::Basic(error),
                 span: start_position..end_position,
             })
         }
@@ -460,9 +472,9 @@ fn parse_at_rule<'i, 't, P>(start_position: SourcePosition, name: Cow<str>,
 }
 
 
-fn parse_qualified_rule<'i, 't, P>(input: &mut Parser<'i, 't>, parser: &mut P)
-                           -> Result<<P as QualifiedRuleParser>::QualifiedRule, ParseError<'i>>
-                           where P: QualifiedRuleParser {
+fn parse_qualified_rule<'i, 't, P, E>(input: &mut Parser<'i, 't>, parser: &mut P)
+                                      -> Result<<P as QualifiedRuleParser>::QualifiedRule, ParseError<'i, E>>
+                                      where P: QualifiedRuleParser<Error = E> {
     let prelude = input.parse_until_before(Delimiter::CurlyBracketBlock, |input| {
         parser.parse_prelude(input)
     });

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,7 +13,7 @@ use rustc_serialize::json::{self, Json, ToJson};
 use self::test::Bencher;
 
 use super::{Parser, Delimiter, Token, NumericValue, PercentageValue, SourceLocation, ParseError,
-            DeclarationListParser, DeclarationParser, RuleListParser,
+            DeclarationListParser, DeclarationParser, RuleListParser, BasicParseError,
             AtRuleType, AtRuleParser, QualifiedRuleParser,
             parse_one_declaration, parse_one_rule, parse_important,
             stylesheet_encoding, EncodingSupport,
@@ -117,9 +117,10 @@ fn component_value_list() {
 #[test]
 fn one_component_value() {
     run_json_tests(include_str!("css-parsing-tests/one_component_value.json"), |input| {
-        input.parse_entirely(|input| {
+        let result: Result<Json, ParseError<()>> = input.parse_entirely(|input| {
             Ok(one_component_value_to_json(try!(input.next()), input))
-        }).unwrap_or(JArray!["error", "invalid"])
+        });
+        result.unwrap_or(JArray!["error", "invalid"])
     });
 }
 
@@ -251,7 +252,11 @@ fn expect_no_error_token() {
 fn outer_block_end_consumed() {
     let mut input = Parser::new("(calc(true))");
     assert!(input.expect_parenthesis_block().is_ok());
-    assert!(input.parse_nested_block(|input| input.expect_function_matching("calc")).is_ok());
+    assert!(input.parse_nested_block(|input| {
+        let result: Result<_, ParseError<()>> = input.expect_function_matching("calc")
+            .map_err(|e| ParseError::Basic(e));
+        result
+    }).is_ok());
     println!("{:?}", input.position());
     assert!(input.next().is_err());
 }
@@ -278,7 +283,7 @@ fn unquoted_url_escaping() {
 
 #[test]
 fn test_expect_url() {
-    fn parse(s: &str) -> Result<Cow<str>, ParseError> {
+    fn parse(s: &str) -> Result<Cow<str>, BasicParseError> {
         Parser::new(s).expect_url()
     }
     assert_eq!(parse("url()").unwrap(), "");
@@ -295,7 +300,10 @@ fn test_expect_url() {
 
 fn run_color_tests<F: Fn(Result<Color, ()>) -> Json>(json_data: &str, to_json: F) {
     run_json_tests(json_data, |input| {
-        to_json(input.parse_entirely(Color::parse).map_err(|_| ()))
+        let result: Result<_, ParseError<()>> = input.parse_entirely(|i| {
+            Color::parse(i).map_err(|e| ParseError::Basic(e))
+        });
+        to_json(result.map_err(|_| ()))
     });
 }
 
@@ -322,14 +330,17 @@ fn color3_keywords() {
 #[test]
 fn nth() {
     run_json_tests(include_str!("css-parsing-tests/An+B.json"), |input| {
-        input.parse_entirely(parse_nth).ok().to_json()
+        input.parse_entirely(|i| {
+            let result: Result<_, ParseError<()>> = parse_nth(i).map_err(|e| ParseError::Basic(e));
+            result
+        }).ok().to_json()
     });
 }
 
 #[test]
 fn unicode_range() {
     run_json_tests(include_str!("css-parsing-tests/urange.json"), |input| {
-        input.parse_comma_separated(|input| {
+        let result: Result<_, ParseError<()>> = input.parse_comma_separated(|input| {
             let result = UnicodeRange::parse(input).ok().map(|r| (r.start, r.end));
             if input.is_exhausted() {
                 Ok(result)
@@ -337,7 +348,8 @@ fn unicode_range() {
                 while let Ok(_) = input.next() {}
                 Ok(None)
             }
-        }).unwrap().to_json()
+        });
+        result.unwrap().to_json()
     });
 }
 
@@ -376,10 +388,11 @@ fn serializer(preserve_comments: bool) {
                     _ => None
                 };
                 if let Some(closing_token) = closing_token {
-                    input.parse_nested_block(|input| {
+                    let result: Result<_, ParseError<()>> = input.parse_nested_block(|input| {
                         write_to(previous_token, input, string, preserve_comments);
                         Ok(())
-                    }).unwrap();
+                    });
+                    result.unwrap();
                     closing_token.to_css(string).unwrap();
                 }
             }
@@ -501,7 +514,10 @@ fn overflow() {
 fn line_delimited() {
     let mut input = Parser::new(" { foo ; bar } baz;,");
     assert_eq!(input.next(), Ok(Token::CurlyBracketBlock));
-    assert!(input.parse_until_after(Delimiter::Semicolon, |_| Ok(42)).is_err());
+    assert!({
+        let result: Result<_, ParseError<()>> = input.parse_until_after(Delimiter::Semicolon, |_| Ok(42));
+        result
+    }.is_err());
     assert_eq!(input.next(), Ok(Token::Comma));
     assert!(input.next().is_err());
 }
@@ -635,9 +651,10 @@ fn no_stack_overflow_multiple_nested_blocks() {
 
 impl DeclarationParser for JsonParser {
     type Declaration = Json;
+    type Error = ();
 
     fn parse_value<'i, 't>(&mut self, name: &str, input: &mut Parser<'i, 't>)
-                           -> Result<Json, ParseError<'i>> {
+                           -> Result<Json, ParseError<'i, ()>> {
         let mut value = vec![];
         let mut important = false;
         loop {
@@ -675,9 +692,10 @@ impl DeclarationParser for JsonParser {
 impl AtRuleParser for JsonParser {
     type Prelude = Vec<Json>;
     type AtRule = Json;
+    type Error = ();
 
     fn parse_prelude<'i, 't>(&mut self, name: &str, input: &mut Parser<'i, 't>)
-                     -> Result<AtRuleType<Vec<Json>, Json>, ParseError<'i>> {
+                     -> Result<AtRuleType<Vec<Json>, Json>, ParseError<'i, ()>> {
         Ok(AtRuleType::OptionalBlock(vec![
             "at-rule".to_json(),
             name.to_json(),
@@ -686,7 +704,7 @@ impl AtRuleParser for JsonParser {
     }
 
     fn parse_block<'i, 't>(&mut self, mut prelude: Vec<Json>, input: &mut Parser<'i, 't>)
-                           -> Result<Json, ParseError<'i>> {
+                           -> Result<Json, ParseError<'i, ()>> {
         prelude.push(Json::Array(component_values_to_json(input)));
         Ok(Json::Array(prelude))
     }
@@ -700,13 +718,14 @@ impl AtRuleParser for JsonParser {
 impl QualifiedRuleParser for JsonParser {
     type Prelude = Vec<Json>;
     type QualifiedRule = Json;
+    type Error = ();
 
-    fn parse_prelude<'i, 't>(&mut self, input: &mut Parser<'i, 't>) -> Result<Vec<Json>, ParseError<'i>> {
+    fn parse_prelude<'i, 't>(&mut self, input: &mut Parser<'i, 't>) -> Result<Vec<Json>, ParseError<'i, ()>> {
         Ok(component_values_to_json(input))
     }
 
     fn parse_block<'i, 't>(&mut self, prelude: Vec<Json>, input: &mut Parser<'i, 't>)
-                           -> Result<Json, ParseError<'i>> {
+                           -> Result<Json, ParseError<'i, ()>> {
         Ok(JArray![
             "qualified rule",
             prelude,
@@ -733,7 +752,10 @@ fn one_component_value_to_json(token: Token, input: &mut Parser) -> Json {
     }
 
     fn nested(input: &mut Parser) -> Vec<Json> {
-        input.parse_nested_block(|input| Ok(component_values_to_json(input))).unwrap()
+        let result: Result<_, ParseError<()>> = input.parse_nested_block(|input| {
+            Ok(component_values_to_json(input))
+        });
+        result.unwrap()
     }
 
     match token {

--- a/src/unicode_range.rs
+++ b/src/unicode_range.rs
@@ -4,7 +4,7 @@
 
 //! https://drafts.csswg.org/css-syntax/#urange
 
-use {Parser, ToCss};
+use {Parser, ToCss, ParseError};
 use std::char;
 use std::cmp;
 use std::fmt;
@@ -24,7 +24,7 @@ pub struct UnicodeRange {
 
 impl UnicodeRange {
     /// https://drafts.csswg.org/css-syntax/#urange-syntax
-    pub fn parse(input: &mut Parser) -> Result<Self, ()> {
+    pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
         // <urange> =
         //   u '+' <ident-token> '?'* |
         //   u <dimension-token> '?'* |
@@ -42,22 +42,25 @@ impl UnicodeRange {
         // but oh well…
         let concatenated_tokens = input.slice_from(after_u);
 
-        let range = parse_concatenated(concatenated_tokens.as_bytes())?;
+        let range = match parse_concatenated(concatenated_tokens.as_bytes()) {
+            Ok(range) => range,
+            Err(()) => return Err(ParseError::UnexpectedToken(Token::Ident(concatenated_tokens.into()))),
+        };
         if range.end > char::MAX as u32 || range.start > range.end {
-            Err(())
+            Err(ParseError::UnexpectedToken(Token::Ident(concatenated_tokens.into())))
         } else {
             Ok(range)
         }
     }
 }
 
-fn parse_tokens(input: &mut Parser) -> Result<(), ()> {
+fn parse_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), ParseError<'i>> {
     match input.next_including_whitespace()? {
         Token::Delim('+') => {
             match input.next_including_whitespace()? {
                 Token::Ident(_) => {}
                 Token::Delim('?') => {}
-                _ => return Err(())
+                t => return Err(ParseError::UnexpectedToken(t))
             }
             parse_question_marks(input)
         }
@@ -73,7 +76,7 @@ fn parse_tokens(input: &mut Parser) -> Result<(), ()> {
                 _ => input.reset(after_number)
             }
         }
-        _ => return Err(())
+        t => return Err(ParseError::UnexpectedToken(t))
     }
     Ok(())
 }

--- a/src/unicode_range.rs
+++ b/src/unicode_range.rs
@@ -4,7 +4,7 @@
 
 //! https://drafts.csswg.org/css-syntax/#urange
 
-use {Parser, ToCss, ParseError};
+use {Parser, ToCss, BasicParseError};
 use std::char;
 use std::cmp;
 use std::fmt;
@@ -24,7 +24,7 @@ pub struct UnicodeRange {
 
 impl UnicodeRange {
     /// https://drafts.csswg.org/css-syntax/#urange-syntax
-    pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
+    pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, BasicParseError<'i>> {
         // <urange> =
         //   u '+' <ident-token> '?'* |
         //   u <dimension-token> '?'* |
@@ -44,23 +44,23 @@ impl UnicodeRange {
 
         let range = match parse_concatenated(concatenated_tokens.as_bytes()) {
             Ok(range) => range,
-            Err(()) => return Err(ParseError::UnexpectedToken(Token::Ident(concatenated_tokens.into()))),
+            Err(()) => return Err(BasicParseError::UnexpectedToken(Token::Ident(concatenated_tokens.into()))),
         };
         if range.end > char::MAX as u32 || range.start > range.end {
-            Err(ParseError::UnexpectedToken(Token::Ident(concatenated_tokens.into())))
+            Err(BasicParseError::UnexpectedToken(Token::Ident(concatenated_tokens.into())))
         } else {
             Ok(range)
         }
     }
 }
 
-fn parse_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), ParseError<'i>> {
+fn parse_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), BasicParseError<'i>> {
     match input.next_including_whitespace()? {
         Token::Delim('+') => {
             match input.next_including_whitespace()? {
                 Token::Ident(_) => {}
                 Token::Delim('?') => {}
-                t => return Err(ParseError::UnexpectedToken(t))
+                t => return Err(BasicParseError::UnexpectedToken(t))
             }
             parse_question_marks(input)
         }
@@ -76,7 +76,7 @@ fn parse_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), ParseError<'i>
                 _ => input.reset(after_number)
             }
         }
-        t => return Err(ParseError::UnexpectedToken(t))
+        t => return Err(BasicParseError::UnexpectedToken(t))
     }
     Ok(())
 }


### PR DESCRIPTION
This shouldn't be merged until the related Servo and Gecko work is complete, but I figured I would put this up for feedback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/143)
<!-- Reviewable:end -->
