### PR TITLE
Treat \n and \r same as other escaped characters

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -253,8 +253,6 @@ impl<'a, W> fmt::Write for CssStringWriter<'a, W> where W: fmt::Write {
             let escaped = match b {
                 b'"' => Some("\\\""),
                 b'\\' => Some("\\\\"),
-                b'\n' => Some("\\A "),
-                b'\r' => Some("\\D "),
                 b'\0' => Some("\u{FFFD}"),
                 b'\x01'...b'\x1F' | b'\x7F' => None,
                 _ => continue,


### PR DESCRIPTION
b'\n' and b'\r' should be serialized to '\\a ' and '\\d ' respectively, rather than '\\A ' and '\\D '. Simply let them be treated the same way as other escaped character should be fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/145)
<!-- Reviewable:end -->
