### PR TITLE
Revert parse error changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cssparser"
-version = "0.14.0"
+version = "0.13.5"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub use from_bytes::{stylesheet_encoding, EncodingSupport};
 pub use color::{RGBA, Color, parse_color_keyword};
 pub use nth::parse_nth;
 pub use serializer::{ToCss, CssStringWriter, serialize_identifier, serialize_string, TokenSerializationType};
-pub use parser::{Parser, Delimiter, Delimiters, SourcePosition, ParseError, BasicParseError};
+pub use parser::{Parser, Delimiter, Delimiters, SourcePosition};
 pub use unicode_range::UnicodeRange;
 
 // For macros

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -4,98 +4,76 @@
 
 use std::ascii::AsciiExt;
 
-use super::{Token, Parser, BasicParseError};
+use super::{Token, Parser};
 
 
 /// Parse the *An+B* notation, as found in the `:nth-child()` selector.
 /// The input is typically the arguments of a function,
 /// in which case the caller needs to check if the arguments’ parser is exhausted.
 /// Return `Ok((A, B))`, or `Err(())` for a syntax error.
-pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), BasicParseError<'i>> {
-    let token = try!(input.next());
-    match token {
-        Token::Number(ref value) => {
-            match value.int_value {
-                Some(v) => Ok((0, v as i32)),
-                None => Err(()),
+pub fn parse_nth(input: &mut Parser) -> Result<(i32, i32), ()> {
+    match try!(input.next()) {
+        Token::Number(value) => Ok((0, try!(value.int_value.ok_or(())) as i32)),
+        Token::Dimension(value, unit) => {
+            let a = try!(value.int_value.ok_or(())) as i32;
+            match_ignore_ascii_case! { &unit,
+                "n" => parse_b(input, a),
+                "n-" => parse_signless_b(input, a, -1),
+                _ => Ok((a, try!(parse_n_dash_digits(&*unit))))
             }
         }
-        Token::Dimension(value, ref unit) => {
-            match value.int_value {
-                Some(v) => {
-                    let a = v as i32;
-                    match_ignore_ascii_case! {
-                        &unit,
-                        "n" => Ok(try!(parse_b(input, a))),
-                        "n-" => Ok(try!(parse_signless_b(input, a, -1))),
-                        _ => {
-                            parse_n_dash_digits(&*unit).map(|val| (a, val))
-                        }
-                    }
-                }
-                None => Err(()),
-            }
-        }
-        Token::Ident(ref value) => {
+        Token::Ident(value) => {
             match_ignore_ascii_case! { &value,
                 "even" => Ok((2, 0)),
                 "odd" => Ok((2, 1)),
-                "n" => Ok(try!(parse_b(input, 1))),
-                "-n" => Ok(try!(parse_b(input, -1))),
-                "n-" => Ok(try!(parse_signless_b(input, 1, -1))),
-                "-n-" => Ok(try!(parse_signless_b(input, -1, -1))),
+                "n" => parse_b(input, 1),
+                "-n" => parse_b(input, -1),
+                "n-" => parse_signless_b(input, 1, -1),
+                "-n-" => parse_signless_b(input, -1, -1),
                 _ => if value.starts_with("-") {
-                    parse_n_dash_digits(&value[1..]).map(|v| (-1, v))
+                    Ok((-1, try!(parse_n_dash_digits(&value[1..]))))
                 } else {
-                    parse_n_dash_digits(&*value).map(|v| (1, v))
+                    Ok((1, try!(parse_n_dash_digits(&*value))))
                 }
             }
         }
         Token::Delim('+') => match try!(input.next_including_whitespace()) {
             Token::Ident(value) => {
                 match_ignore_ascii_case! { &value,
-                    "n" => Ok(try!(parse_b(input, 1))),
-                    "n-" => Ok(try!(parse_signless_b(input, 1, -1))),
-                    _ => parse_n_dash_digits(&*value).map(|v| (1, v))
+                    "n" => parse_b(input, 1),
+                    "n-" => parse_signless_b(input, 1, -1),
+                    _ => Ok((1, try!(parse_n_dash_digits(&*value))))
                 }
             }
-            t => return Err(BasicParseError::UnexpectedToken(t)),
+            _ => Err(())
         },
-        _ => Err(()),
-    }.map_err(|()| BasicParseError::UnexpectedToken(token))
+        _ => Err(())
+    }
 }
 
 
-fn parse_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32) -> Result<(i32, i32), BasicParseError<'i>> {
+fn parse_b(input: &mut Parser, a: i32) -> Result<(i32, i32), ()> {
     let start_position = input.position();
-    let token = input.next();
-    match token {
-        Ok(Token::Delim('+')) => Ok(try!(parse_signless_b(input, a, 1))),
-        Ok(Token::Delim('-')) => Ok(try!(parse_signless_b(input, a, -1))),
+    match input.next() {
+        Ok(Token::Delim('+')) => parse_signless_b(input, a, 1),
+        Ok(Token::Delim('-')) => parse_signless_b(input, a, -1),
         Ok(Token::Number(ref value)) if value.has_sign => {
-            match value.int_value {
-                Some(v) => Ok((a, v as i32)),
-                None => Err(()),
-            }
+            Ok((a, try!(value.int_value.ok_or(())) as i32))
         }
         _ => {
             input.reset(start_position);
             Ok((a, 0))
         }
-    }.map_err(|()| BasicParseError::UnexpectedToken(token.unwrap()))
+    }
 }
 
-fn parse_signless_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32, b_sign: i32) -> Result<(i32, i32), BasicParseError<'i>> {
-    let token = try!(input.next());
-    match token {
+fn parse_signless_b(input: &mut Parser, a: i32, b_sign: i32) -> Result<(i32, i32), ()> {
+    match try!(input.next()) {
         Token::Number(ref value) if !value.has_sign => {
-            match value.int_value {
-                Some(v) => Ok((a, b_sign * v as i32)),
-                None => Err(()),
-            }
+            Ok((a, b_sign * (try!(value.int_value.ok_or(())) as i32)))
         }
         _ => Err(())
-    }.map_err(|()| BasicParseError::UnexpectedToken(token))
+    }
 }
 
 fn parse_n_dash_digits(string: &str) -> Result<i32, ()> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,45 +21,6 @@ pub struct SourcePosition {
     at_start_of: Option<BlockType>,
 }
 
-/// The funamental parsing errors that can be triggered by built-in parsing routines.
-#[derive(Clone, Debug, PartialEq)]
-pub enum BasicParseError<'a> {
-    /// An unexpected token was encountered.
-    UnexpectedToken(Token<'a>),
-    /// A particular token was expected but not found.
-    ExpectedToken(Token<'a>),
-    /// The end of the input was encountered unexpectedly.
-    EndOfInput,
-    /// An `@` rule was encountered that was invalid.
-    AtRuleInvalid,
-    /// A qualified rule was encountered that was invalid.
-    QualifiedRuleInvalid,
-}
-
-impl<'a, T> From<BasicParseError<'a>> for ParseError<'a, T> {
-    fn from(this: BasicParseError<'a>) -> ParseError<'a, T> {
-        ParseError::Basic(this)
-    }
-}
-
-/// Extensible parse errors that can be encountered by client parsing implementations.
-#[derive(Clone, Debug, PartialEq)]
-pub enum ParseError<'a, T: 'a> {
-    /// A fundamental parse error from a built-in parsing routine.
-    Basic(BasicParseError<'a>),
-    /// A parse error reported by downstream consumer code.
-    Custom(T),
-}
-
-impl<'a, T> ParseError<'a, T> {
-    /// Extract the fundamental parse error from an extensible error.
-    pub fn basic(self) -> BasicParseError<'a> {
-        match self {
-            ParseError::Basic(e) => e,
-            ParseError::Custom(_) => panic!("Not a basic parse error"),
-        }
-    }
-}
 
 /// Like std::borrow::Cow, except the borrowed variant contains a mutable
 /// reference.
@@ -227,12 +188,13 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// This ignores whitespace and comments.
     #[inline]
-    pub fn expect_exhausted(&mut self) -> Result<(), BasicParseError<'i>> {
+    pub fn expect_exhausted(&mut self) -> Result<(), ()> {
         let start_position = self.position();
         let result = match self.next() {
-            Err(BasicParseError::EndOfInput) => Ok(()),
-            Err(e) => unreachable!("Unexpected error encountered: {:?}", e),
-            Ok(t) => Err(BasicParseError::UnexpectedToken(t)),
+            Err(()) => Ok(()),
+            Ok(_) => {
+                Err(())
+            }
         };
         self.reset(start_position);
         result
@@ -336,7 +298,7 @@ impl<'i, 't> Parser<'i, 't> {
     /// See the `Parser::parse_nested_block` method to parse the content of functions or blocks.
     ///
     /// This only returns a closing token when it is unmatched (and therefore an error).
-    pub fn next(&mut self) -> Result<Token<'i>, BasicParseError<'i>> {
+    pub fn next(&mut self) -> Result<Token<'i>, ()> {
         loop {
             match self.next_including_whitespace_and_comments() {
                 Ok(Token::WhiteSpace(_)) | Ok(Token::Comment(_)) => {},
@@ -346,7 +308,7 @@ impl<'i, 't> Parser<'i, 't> {
     }
 
     /// Same as `Parser::next`, but does not skip whitespace tokens.
-    pub fn next_including_whitespace(&mut self) -> Result<Token<'i>, BasicParseError<'i>> {
+    pub fn next_including_whitespace(&mut self) -> Result<Token<'i>, ()> {
         loop {
             match self.next_including_whitespace_and_comments() {
                 Ok(Token::Comment(_)) => {},
@@ -361,15 +323,14 @@ impl<'i, 't> Parser<'i, 't> {
     /// where comments are preserved.
     /// When parsing higher-level values, per the CSS Syntax specification,
     /// comments should always be ignored between tokens.
-    pub fn next_including_whitespace_and_comments(&mut self) -> Result<Token<'i>, BasicParseError<'i>> {
+    pub fn next_including_whitespace_and_comments(&mut self) -> Result<Token<'i>, ()> {
         if let Some(block_type) = self.at_start_of.take() {
             consume_until_end_of_block(block_type, &mut *self.tokenizer);
         }
-        let byte = self.tokenizer.next_byte();
-        if self.stop_before.contains(Delimiters::from_byte(byte)) {
-            return Err(BasicParseError::EndOfInput)
+        if self.stop_before.contains(Delimiters::from_byte(self.tokenizer.next_byte())) {
+            return Err(())
         }
-        let token = try!(self.tokenizer.next().map_err(|()| BasicParseError::EndOfInput));
+        let token = try!(self.tokenizer.next());
         if let Some(block_type) = BlockType::opening(&token) {
             self.at_start_of = Some(block_type);
         }
@@ -381,8 +342,8 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// This can help tell e.g. `color: green;` from `color: green 4px;`
     #[inline]
-    pub fn parse_entirely<F, T, E>(&mut self, parse: F) -> Result<T, ParseError<'i, E>>
-    where F: FnOnce(&mut Parser<'i, 't>) -> Result<T, ParseError<'i, E>> {
+    pub fn parse_entirely<F, T>(&mut self, parse: F) -> Result<T, ()>
+    where F: FnOnce(&mut Parser<'i, 't>) -> Result<T, ()> {
         let result = parse(self);
         try!(self.expect_exhausted());
         result
@@ -399,13 +360,13 @@ impl<'i, 't> Parser<'i, 't> {
     /// This method retuns `Err(())` the first time that a closure call does,
     /// or if a closure call leaves some input before the next comma or the end of the input.
     #[inline]
-    pub fn parse_comma_separated<F, T, E>(&mut self, mut parse_one: F) -> Result<Vec<T>, ParseError<'i, E>>
-    where F: for <'ii, 'tt> FnMut(&mut Parser<'ii, 'tt>) -> Result<T, ParseError<'ii, E>> {
+    pub fn parse_comma_separated<F, T>(&mut self, mut parse_one: F) -> Result<Vec<T>, ()>
+    where F: FnMut(&mut Parser) -> Result<T, ()> {
         let mut values = vec![];
         loop {
             values.push(try!(self.parse_until_before(Delimiter::Comma, |parser| parse_one(parser))));
             match self.next() {
-                Err(_) => return Ok(values),
+                Err(()) => return Ok(values),
                 Ok(Token::Comma) => continue,
                 Ok(_) => unreachable!(),
             }
@@ -424,8 +385,8 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// The result is overridden to `Err(())` if the closure leaves some input before that point.
     #[inline]
-    pub fn parse_nested_block<F, T, E>(&mut self, parse: F) -> Result <T, ParseError<'i, E>>
-    where F: for<'tt> FnOnce(&mut Parser<'i, 'tt>) -> Result<T, ParseError<'i, E>> {
+    pub fn parse_nested_block<F, T>(&mut self, parse: F) -> Result <T, ()>
+    where F: for<'tt> FnOnce(&mut Parser<'i, 'tt>) -> Result<T, ()> {
         let block_type = self.at_start_of.take().expect("\
             A nested parser can only be created when a Function, \
             ParenthesisBlock, SquareBracketBlock, or CurlyBracketBlock \
@@ -461,9 +422,9 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// The result is overridden to `Err(())` if the closure leaves some input before that point.
     #[inline]
-    pub fn parse_until_before<F, T, E>(&mut self, delimiters: Delimiters, parse: F)
-                                    -> Result <T, ParseError<'i, E>>
-    where F: for<'ii, 'tt> FnOnce(&mut Parser<'ii, 'tt>) -> Result<T, ParseError<'ii, E>> {
+    pub fn parse_until_before<F, T>(&mut self, delimiters: Delimiters, parse: F)
+                                    -> Result <T, ()>
+    where F: for<'tt> FnOnce(&mut Parser<'i, 'tt>) -> Result<T, ()> {
         let delimiters = self.stop_before | delimiters;
         let result;
         // Introduce a new scope to limit duration of nested_parser’s borrow
@@ -500,9 +461,9 @@ impl<'i, 't> Parser<'i, 't> {
     /// (e.g. if these is only one in the given set)
     /// or if it was there at all (as opposed to reaching the end of the input).
     #[inline]
-    pub fn parse_until_after<F, T, E>(&mut self, delimiters: Delimiters, parse: F)
-                                   -> Result <T, ParseError<'i, E>>
-    where F: for<'ii, 'tt> FnOnce(&mut Parser<'ii, 'tt>) -> Result<T, ParseError<'ii, E>> {
+    pub fn parse_until_after<F, T>(&mut self, delimiters: Delimiters, parse: F)
+                                   -> Result <T, ()>
+    where F: for<'tt> FnOnce(&mut Parser<'i, 'tt>) -> Result<T, ()> {
         let result = self.parse_until_before(delimiters, parse);
         let next_byte = self.tokenizer.next_byte();
         if next_byte.is_some() && !self.stop_before.contains(Delimiters::from_byte(next_byte)) {
@@ -517,142 +478,136 @@ impl<'i, 't> Parser<'i, 't> {
 
     /// Parse a <whitespace-token> and return its value.
     #[inline]
-    pub fn expect_whitespace(&mut self) -> Result<&'i str, BasicParseError<'i>> {
+    pub fn expect_whitespace(&mut self) -> Result<&'i str, ()> {
         match try!(self.next_including_whitespace()) {
             Token::WhiteSpace(value) => Ok(value),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse a <ident-token> and return the unescaped value.
     #[inline]
-    pub fn expect_ident(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
+    pub fn expect_ident(&mut self) -> Result<Cow<'i, str>, ()> {
         match try!(self.next()) {
             Token::Ident(value) => Ok(value),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse a <ident-token> whose unescaped value is an ASCII-insensitive match for the given value.
     #[inline]
-    pub fn expect_ident_matching(&mut self, expected_value: &str) -> Result<(), BasicParseError<'i>> {
+    pub fn expect_ident_matching(&mut self, expected_value: &str) -> Result<(), ()> {
         match try!(self.next()) {
             Token::Ident(ref value) if value.eq_ignore_ascii_case(expected_value) => Ok(()),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse a <string-token> and return the unescaped value.
     #[inline]
-    pub fn expect_string(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
+    pub fn expect_string(&mut self) -> Result<Cow<'i, str>, ()> {
         match try!(self.next()) {
             Token::QuotedString(value) => Ok(value),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse either a <ident-token> or a <string-token>, and return the unescaped value.
     #[inline]
-    pub fn expect_ident_or_string(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
+    pub fn expect_ident_or_string(&mut self) -> Result<Cow<'i, str>, ()> {
         match try!(self.next()) {
             Token::Ident(value) => Ok(value),
             Token::QuotedString(value) => Ok(value),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse a <url-token> and return the unescaped value.
     #[inline]
-    pub fn expect_url(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
+    pub fn expect_url(&mut self) -> Result<Cow<'i, str>, ()> {
         match try!(self.next()) {
             Token::UnquotedUrl(value) => Ok(value),
             Token::Function(ref name) if name.eq_ignore_ascii_case("url") => {
-                self.parse_nested_block(|input| input.expect_string()
-                                        .map_err(|e| ParseError::Basic(e)))
-                    .map_err(ParseError::<()>::basic)
+                self.parse_nested_block(|input| input.expect_string())
             },
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse either a <url-token> or a <string-token>, and return the unescaped value.
     #[inline]
-    pub fn expect_url_or_string(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
+    pub fn expect_url_or_string(&mut self) -> Result<Cow<'i, str>, ()> {
         match try!(self.next()) {
             Token::UnquotedUrl(value) => Ok(value),
             Token::QuotedString(value) => Ok(value),
             Token::Function(ref name) if name.eq_ignore_ascii_case("url") => {
-                self.parse_nested_block(|input| input.expect_string().map_err(|e| ParseError::Basic(e)))
-                    .map_err(ParseError::<()>::basic)
+                self.parse_nested_block(|input| input.expect_string())
             },
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse a <number-token> and return the integer value.
     #[inline]
-    pub fn expect_number(&mut self) -> Result<f32, BasicParseError<'i>> {
+    pub fn expect_number(&mut self) -> Result<f32, ()> {
         match try!(self.next()) {
             Token::Number(NumericValue { value, .. }) => Ok(value),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse a <number-token> that does not have a fractional part, and return the integer value.
     #[inline]
-    pub fn expect_integer(&mut self) -> Result<i32, BasicParseError<'i>> {
-        let token = try!(self.next());
-        match token {
-            Token::Number(NumericValue { int_value: Some(int_value), .. }) => {
-                Ok(int_value)
-            }
-            t => Err(BasicParseError::UnexpectedToken(t))
+    pub fn expect_integer(&mut self) -> Result<i32, ()> {
+        match try!(self.next()) {
+            Token::Number(NumericValue { int_value, .. }) => int_value.ok_or(()),
+            _ => Err(())
         }
     }
 
     /// Parse a <percentage-token> and return the value.
     /// `0%` and `100%` map to `0.0` and `1.0` (not `100.0`), respectively.
     #[inline]
-    pub fn expect_percentage(&mut self) -> Result<f32, BasicParseError<'i>> {
+    pub fn expect_percentage(&mut self) -> Result<f32, ()> {
         match try!(self.next()) {
             Token::Percentage(PercentageValue { unit_value, .. }) => Ok(unit_value),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse a `:` <colon-token>.
     #[inline]
-    pub fn expect_colon(&mut self) -> Result<(), BasicParseError<'i>> {
+    pub fn expect_colon(&mut self) -> Result<(), ()> {
         match try!(self.next()) {
             Token::Colon => Ok(()),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse a `;` <semicolon-token>.
     #[inline]
-    pub fn expect_semicolon(&mut self) -> Result<(), BasicParseError<'i>> {
+    pub fn expect_semicolon(&mut self) -> Result<(), ()> {
         match try!(self.next()) {
             Token::Semicolon => Ok(()),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse a `,` <comma-token>.
     #[inline]
-    pub fn expect_comma(&mut self) -> Result<(), BasicParseError<'i>> {
+    pub fn expect_comma(&mut self) -> Result<(), ()> {
         match try!(self.next()) {
             Token::Comma => Ok(()),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
     /// Parse a <delim-token> with the given value.
     #[inline]
-    pub fn expect_delim(&mut self, expected_value: char) -> Result<(), BasicParseError<'i>> {
+    pub fn expect_delim(&mut self, expected_value: char) -> Result<(), ()> {
         match try!(self.next()) {
             Token::Delim(value) if value == expected_value => Ok(()),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
@@ -660,10 +615,10 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// If the result is `Ok`, you can then call the `Parser::parse_nested_block` method.
     #[inline]
-    pub fn expect_curly_bracket_block(&mut self) -> Result<(), BasicParseError<'i>> {
+    pub fn expect_curly_bracket_block(&mut self) -> Result<(), ()> {
         match try!(self.next()) {
             Token::CurlyBracketBlock => Ok(()),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
@@ -671,10 +626,10 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// If the result is `Ok`, you can then call the `Parser::parse_nested_block` method.
     #[inline]
-    pub fn expect_square_bracket_block(&mut self) -> Result<(), BasicParseError<'i>> {
+    pub fn expect_square_bracket_block(&mut self) -> Result<(), ()> {
         match try!(self.next()) {
             Token::SquareBracketBlock => Ok(()),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
@@ -682,10 +637,10 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// If the result is `Ok`, you can then call the `Parser::parse_nested_block` method.
     #[inline]
-    pub fn expect_parenthesis_block(&mut self) -> Result<(), BasicParseError<'i>> {
+    pub fn expect_parenthesis_block(&mut self) -> Result<(), ()> {
         match try!(self.next()) {
             Token::ParenthesisBlock => Ok(()),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
@@ -693,10 +648,10 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// If the result is `Ok`, you can then call the `Parser::parse_nested_block` method.
     #[inline]
-    pub fn expect_function(&mut self) -> Result<Cow<'i, str>, BasicParseError<'i>> {
+    pub fn expect_function(&mut self) -> Result<Cow<'i, str>, ()> {
         match try!(self.next()) {
             Token::Function(name) => Ok(name),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
@@ -704,10 +659,10 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// If the result is `Ok`, you can then call the `Parser::parse_nested_block` method.
     #[inline]
-    pub fn expect_function_matching(&mut self, expected_name: &str) -> Result<(), BasicParseError<'i>> {
+    pub fn expect_function_matching(&mut self, expected_name: &str) -> Result<(), ()> {
         match try!(self.next()) {
             Token::Function(ref name) if name.eq_ignore_ascii_case(expected_name) => Ok(()),
-            t => Err(BasicParseError::UnexpectedToken(t))
+            _ => Err(())
         }
     }
 
@@ -715,22 +670,19 @@ impl<'i, 't> Parser<'i, 't> {
     ///
     /// See `Token::is_parse_error`. This also checks nested blocks and functions recursively.
     #[inline]
-    pub fn expect_no_error_token(&mut self) -> Result<(), BasicParseError<'i>> {
+    pub fn expect_no_error_token(&mut self) -> Result<(), ()> {
         loop {
             match self.next_including_whitespace_and_comments() {
                 Ok(Token::Function(_)) | Ok(Token::ParenthesisBlock) |
                 Ok(Token::SquareBracketBlock) | Ok(Token::CurlyBracketBlock) => {
-                    let result = self.parse_nested_block(|input| input.expect_no_error_token()
-                                                         .map_err(|e| ParseError::Basic(e)));
-                    try!(result.map_err(ParseError::<()>::basic))
+                    try!(self.parse_nested_block(|input| input.expect_no_error_token()))
                 }
                 Ok(token) => {
                     if token.is_parse_error() {
-                        //FIXME: maybe these should be separate variants of BasicParseError instead?
-                        return Err(BasicParseError::UnexpectedToken(token))
+                        return Err(())
                     }
                 }
-                Err(_) => return Ok(())
+                Err(()) => return Ok(())
             }
         }
     }

--- a/src/unicode_range.rs
+++ b/src/unicode_range.rs
@@ -4,7 +4,7 @@
 
 //! https://drafts.csswg.org/css-syntax/#urange
 
-use {Parser, ToCss, BasicParseError};
+use {Parser, ToCss};
 use std::char;
 use std::cmp;
 use std::fmt;
@@ -24,7 +24,7 @@ pub struct UnicodeRange {
 
 impl UnicodeRange {
     /// https://drafts.csswg.org/css-syntax/#urange-syntax
-    pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, BasicParseError<'i>> {
+    pub fn parse(input: &mut Parser) -> Result<Self, ()> {
         // <urange> =
         //   u '+' <ident-token> '?'* |
         //   u <dimension-token> '?'* |
@@ -42,25 +42,22 @@ impl UnicodeRange {
         // but oh well…
         let concatenated_tokens = input.slice_from(after_u);
 
-        let range = match parse_concatenated(concatenated_tokens.as_bytes()) {
-            Ok(range) => range,
-            Err(()) => return Err(BasicParseError::UnexpectedToken(Token::Ident(concatenated_tokens.into()))),
-        };
+        let range = parse_concatenated(concatenated_tokens.as_bytes())?;
         if range.end > char::MAX as u32 || range.start > range.end {
-            Err(BasicParseError::UnexpectedToken(Token::Ident(concatenated_tokens.into())))
+            Err(())
         } else {
             Ok(range)
         }
     }
 }
 
-fn parse_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), BasicParseError<'i>> {
+fn parse_tokens(input: &mut Parser) -> Result<(), ()> {
     match input.next_including_whitespace()? {
         Token::Delim('+') => {
             match input.next_including_whitespace()? {
                 Token::Ident(_) => {}
                 Token::Delim('?') => {}
-                t => return Err(BasicParseError::UnexpectedToken(t))
+                _ => return Err(())
             }
             parse_question_marks(input)
         }
@@ -76,7 +73,7 @@ fn parse_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), BasicParseErro
                 _ => input.reset(after_number)
             }
         }
-        t => return Err(BasicParseError::UnexpectedToken(t))
+        _ => return Err(())
     }
     Ok(())
 }


### PR DESCRIPTION
The API changes should not merge until the downstream consumers are ready.

This reverts commit 0a70d228aca1f60b1d838bbe4b471bfa9c6bb557, reversing
changes made to fc0bdcd1845e3aa616c3bdd15127aed259b87cb8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/148)
<!-- Reviewable:end -->
