### PR TITLE
RFC: Use Rust's string-to-number conversions, instead of home-grown ones

### DIFF
--- a/src/rules_and_declarations.rs
+++ b/src/rules_and_declarations.rs
@@ -77,7 +77,7 @@ pub trait DeclarationParser<'i> {
 ///
 /// Default implementations that reject all at-rules are provided,
 /// so that `impl AtRuleParser<(), ()> for ... {}` can be used
-/// for using `DeclarationListParser` to parse a declartions list with only qualified rules.
+/// for using `DeclarationListParser` to parse a declarations list with only qualified rules.
 pub trait AtRuleParser<'i> {
     /// The intermediate representation of prelude of an at-rule without block;
     type PreludeNoBlock;


### PR DESCRIPTION
Rust's standard library contains pretty sophisticated code for parsing numbers from strings.  This pull request modifies Tokenizer to that, instead of using a trivial "multiply by 10 and add the digit" algorithm.

However, this makes the tests fail!

For example, one of the tests parses a "`.67%`" token out of a bigger component-value-list, and the token has a spec like
```
	["percentage", "0.66999996", 0.67, "number"], " ",
```

and it fails with
```
        [
          "percentage",
result    "0.67",
result    0.6700000166893005,
expect    "0.66999996",
expect    0.6700000000000002,
          "number"
        ],
```

Some things to note:

* The test code uses the rustc-serialize crate to read/write JSON, but that crate says it has been deprecated in favor of Serde.
* rustc-serialize *also* uses a simple algorithm like rust-cssparser, where numbers are parsed by multiplying by 10 and adding each digit.
* The test code uses rust-cssparser's serializer.rs to generate JSON out of the parsed tokens.  It writes the string representations of numbers by doing a simple `write!(writer, "{}", float)`.  In the example above, this is what generates the `"0.67"` in the first result line, but that is different from the test fixture's expected `"0.66999996"`.  I am not sure which side to trust :)
* Even though the result/expected numbers (not the stringified values) are different in the example above, the JSON code assumes f64, while Token uses f32.  Also, almost_equals() in tests.rs compares the absolute value of the difference between result/expected to be < 1e-6 - I haven't dug deep enough to see why this comparison is failing for the example above.

I'm fine with this pull request not being merged, since the tests fail - but I'm not sure how those test values were generated in the first place?

Comments on the above are appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/156)
<!-- Reviewable:end -->
