### PR TITLE
Use u32 for SourceLocation

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -309,7 +309,7 @@ impl<'a> Tokenizer<'a> {
             location.column = 1;
         }
         debug_assert!(position <= target);
-        location.column += target - position;
+        location.column += (target - position) as u32;
         self.last_known_source_location.set((SourcePosition(target), location));
         location
     }
@@ -383,10 +383,10 @@ pub struct SourcePosition(usize);
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct SourceLocation {
     /// The line number, starting at 1 for the first line.
-    pub line: usize,
+    pub line: u32,
 
     /// The column number within a line, starting at 1 for first the character of the line.
-    pub column: usize,
+    pub column: u32,
 }
 
 


### PR DESCRIPTION
I suppose nothing is going to be happy if a CSS file can contain over 4G lines or columns...

All Servo rules have `SourceLocation` stored, so reducing its size is probably worth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/157)
<!-- Reviewable:end -->
