### PR TITLE
Serialize currentcolor as canonicalized form

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cssparser"
-version = "0.16.0"
+version = "0.17.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/color.rs
+++ b/src/color.rs
@@ -118,7 +118,7 @@ impl ToCss for RGBA {
 /// A <color> value.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Color {
-    /// The 'currentColor' keyword
+    /// The 'currentcolor' keyword
     CurrentColor,
     /// Everything else gets converted to RGBA during parsing
     RGBA(RGBA),
@@ -130,7 +130,7 @@ known_heap_size!(0, Color);
 impl ToCss for Color {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
         match *self {
-            Color::CurrentColor => dest.write_str("currentColor"),
+            Color::CurrentColor => dest.write_str("currentcolor"),
             Color::RGBA(ref rgba) => rgba.to_css(dest),
         }
     }

--- a/src/css-parsing-tests/README.rst
+++ b/src/css-parsing-tests/README.rst
@@ -116,7 +116,7 @@ associated with the expected result.
     the output as one of:
 
     * null if the input is not a valid color in CSS syntax
-    * The string "currentColor" for the currentColor keyword
+    * The string "currentcolor" for the currentcolor keyword
     * An array of length 4 for every other values:
       four (floating point) numbers for the Red, Green, Blue and Alpha channel.
       Each value is between 0 and 1.

--- a/src/css-parsing-tests/color3.json
+++ b/src/css-parsing-tests/color3.json
@@ -7,8 +7,9 @@
 "transparent", [0, 0, 0, 0],
 " transparent\n", [0, 0, 0, 0],
 "TransParent", [0, 0, 0, 0],
-"currentColor", "currentColor",
-"CURRENTcolor", "currentColor",
+"currentcolor", "currentcolor",
+"currentColor", "currentcolor",
+"CURRENTcolor", "currentcolor",
 "current-Color", null,
 
 "black", [0, 0, 0, 255],

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -426,7 +426,7 @@ fn serializer(preserve_comments: bool) {
 #[test]
 fn serialize_current_color() {
     let c = Color::CurrentColor;
-    assert!(c.to_css_string() == "currentColor");
+    assert!(c.to_css_string() == "currentcolor");
 }
 
 #[test]
@@ -622,7 +622,7 @@ impl ToJson for Color {
             Color::RGBA(ref rgba) => {
                 [rgba.red, rgba.green, rgba.blue, rgba.alpha].to_json()
             },
-            Color::CurrentColor => "currentColor".to_json(),
+            Color::CurrentColor => "currentcolor".to_json(),
         }
     }
 }


### PR DESCRIPTION
Serialize currentcolor as canonicalized form instead of currentColor. This is needed for servo/servo#15397
I'm not sure about version bump though. Is that a breaking change?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/162)
<!-- Reviewable:end -->
