### PR TITLE
actually exclude test files from packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["css", "syntax", "parser"]
 license = "MPL-2.0"
 build = "build.rs"
 
-exclude = ["src/css-parsing-tests"]
+exclude = ["src/css-parsing-tests/**", "src/big-data-url.css"]
 
 [dev-dependencies]
 rustc-serialize = "0.3"


### PR DESCRIPTION
package.exclude takes glob syntax for determining what files to exclude
when excluding directories.

Fixes #169.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/170)
<!-- Reviewable:end -->
