### PR TITLE
Serialize number to no more than necessary precision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.19.1"
+version = "0.19.2"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"
@@ -20,6 +20,7 @@ encoding_rs = "0.5"
 
 [dependencies]
 cssparser-macros = {path = "./macros", version = "0.3"}
+dtoa-short = "0.3"
 heapsize = {version = ">= 0.3, < 0.5", optional = true}
 matches = "0.1"
 phf = "0.7"

--- a/src/css-parsing-tests/component_value_list.json
+++ b/src/css-parsing-tests/component_value_list.json
@@ -247,6 +247,12 @@
 	["number", "-0.67", -0.67, "number"]
 ],
 
+"12.3e30 -0.0123e30 9999e-13", [
+	["number", "1.23e31", 1.23e31, "number"], " ",
+	["number", "-1.23e28", -1.23e28, "number"], " ",
+	["number", "9.999e-10", 9.999e-10, "number"]
+],
+
 "3. /* Decimal point must have following digits */", [
 	["number", "3", 3, "integer"], ".", " "
 ],
@@ -264,12 +270,12 @@
 	["percentage", "12", 12, "integer"], " ",
 	["percentage", "+34", 34, "integer"], " ",
 	["percentage", "-45", -45, "integer"], " ",
-	["percentage", "0.66999996", 0.67, "number"], " ",
+	["percentage", "0.67", 0.67, "number"], " ",
 	["percentage", "+0.89", 0.89, "number"], " ",
 	["percentage", "-0.01", -0.01, "number"], " ",
 	["percentage", "2.3", 2.3000000000, "number"], " ",
 	["percentage", "+45.0", 45.0, "number"], " ",
-	["percentage", "-0.66999996", -0.67, "number"]
+	["percentage", "-0.67", -0.67, "number"]
 ],
 
 "12e2% +34e+1% -45E-0% .68e+3% +.79e-1% -.01E2% 2.3E+1% +45.0e6% -0.67e0%", [
@@ -281,7 +287,7 @@
 	["percentage", "-1.0", -1, "number"], " ",
 	["percentage", "23.0", 23, "number"], " ",
 	["percentage", "+45000000.0", 45000000, "number"], " ",
-	["percentage", "-0.66999996", -0.67, "number"]
+	["percentage", "-0.67", -0.67, "number"]
 ],
 
 "12\\% /* Percent sign can not be escaped */", [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ fn parse_border_spacing(_context: &ParserContext, input: &mut Parser)
 
 #![recursion_limit="200"]  // For color::parse_color_keyword
 
+extern crate dtoa_short;
 #[macro_use] extern crate cssparser_macros;
 #[macro_use] extern crate matches;
 #[macro_use] extern crate procedural_masquerade;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,7 +31,7 @@ fn almost_equals(a: &Json, b: &Json) -> bool {
         (_, &Json::I64(b)) => almost_equals(a, &Json::F64(b as f64)),
         (_, &Json::U64(b)) => almost_equals(a, &Json::F64(b as f64)),
 
-        (&Json::F64(a), &Json::F64(b)) => (a - b).abs() < 1e-6,
+        (&Json::F64(a), &Json::F64(b)) => (a - b).abs() <= a.abs() * 1e-6,
 
         (&Json::Boolean(a), &Json::Boolean(b)) => a == b,
         (&Json::String(ref a), &Json::String(ref b)) => a == b,
@@ -1002,5 +1002,27 @@ fn parse_comments() {
         while let Ok(_) = parser.next_including_whitespace() {
         }
         assert_eq!(parser.current_source_map_url(), test.1);
+    }
+}
+
+#[test]
+fn roundtrip_percentage_token() {
+    fn test_roundtrip(value: &str) {
+        let mut input = ParserInput::new(value);
+        let mut parser = Parser::new(&mut input);
+        let token = parser.next().unwrap();
+        assert_eq!(token.to_css_string(), value);
+    }
+    // Test simple number serialization
+    for i in 0..101 {
+        test_roundtrip(&format!("{}%", i));
+        for j in 0..10 {
+            if j != 0 {
+                test_roundtrip(&format!("{}.{}%", i, j));
+            }
+            for k in 1..10 {
+                test_roundtrip(&format!("{}.{}{}%", i, j, k));
+            }
+        }
     }
 }


### PR DESCRIPTION
I'm not sure whether it can be simplified... and I probably need some more idea for how should I test it... But things look fine so far.

This should probably goes to an independent crate at some point.

It should fix servo/servo#17205.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/173)
<!-- Reviewable:end -->
