### PR TITLE
Fix a panic in bad-url token parsing. Fix #174.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "cssparser"
-version = "0.18.0"
+version = "0.18.1"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -271,6 +271,14 @@ fn outer_block_end_consumed() {
     assert!(input.next().is_err());
 }
 
+/// https://github.com/servo/rust-cssparser/issues/174
+#[test]
+fn bad_url_slice_out_of_bounds() {
+    let mut input = ParserInput::new("url(\u{1}\\");
+    let mut parser = Parser::new(&mut input);
+    let _ = parser.next_including_whitespace_and_comments(); // This used to panic
+}
+
 #[test]
 fn unquoted_url_escaping() {
     let token = Token::UnquotedUrl("\

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1048,7 +1048,9 @@ fn consume_unquoted_url<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, 
             match_byte! { tokenizer.consume_byte(),
                 b')' => { break },
                 b'\\' => {
-                    tokenizer.advance(1); // Skip an escaped ')' or '\'
+                    if matches!(tokenizer.next_byte(), Some(b')') | Some(b'\\')) {
+                        tokenizer.advance(1); // Skip an escaped ')' or '\'
+                    }
                 }
                 _ => {},
             }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/175)
<!-- Reviewable:end -->
