### PR TITLE
Count line-numbers during tokenization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
-
 name = "cssparser"
-version = "0.18.2"
+version = "0.19.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub use cssparser_macros::*;
 pub use tokenizer::{Token, SourceLocation};
 pub use rules_and_declarations::{parse_important};
 pub use rules_and_declarations::{DeclarationParser, DeclarationListParser, parse_one_declaration};
-pub use rules_and_declarations::{RuleListParser, parse_one_rule};
+pub use rules_and_declarations::{RuleListParser, parse_one_rule, PreciseParseError};
 pub use rules_and_declarations::{AtRuleType, QualifiedRuleParser, AtRuleParser};
 pub use from_bytes::{stylesheet_encoding, EncodingSupport};
 pub use color::{RGBA, Color, parse_color_keyword};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ fn parse_border_spacing(_context: &ParserContext, input: &mut Parser)
 
 pub use cssparser_macros::*;
 
-pub use tokenizer::{Token, SourceLocation};
+pub use tokenizer::{Token, SourcePosition, SourceLocation};
 pub use rules_and_declarations::{parse_important};
 pub use rules_and_declarations::{DeclarationParser, DeclarationListParser, parse_one_declaration};
 pub use rules_and_declarations::{RuleListParser, parse_one_rule, PreciseParseError};
@@ -89,7 +89,7 @@ pub use from_bytes::{stylesheet_encoding, EncodingSupport};
 pub use color::{RGBA, Color, parse_color_keyword};
 pub use nth::parse_nth;
 pub use serializer::{ToCss, CssStringWriter, serialize_identifier, serialize_string, TokenSerializationType};
-pub use parser::{Parser, Delimiter, Delimiters, SourcePosition, ParseError, BasicParseError, ParserInput};
+pub use parser::{Parser, Delimiter, Delimiters, ParserState, ParseError, BasicParseError, ParserInput};
 pub use unicode_range::UnicodeRange;
 pub use cow_rc_str::CowRcStr;
 

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -69,13 +69,13 @@ pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), Basic
 
 
 fn parse_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32) -> Result<(i32, i32), BasicParseError<'i>> {
-    let start_position = input.position();
+    let start = input.state();
     match input.next() {
         Ok(&Token::Delim('+')) => parse_signless_b(input, a, 1),
         Ok(&Token::Delim('-')) => parse_signless_b(input, a, -1),
         Ok(&Token::Number { has_sign: true, int_value: Some(b), .. }) => Ok((a, b)),
         _ => {
-            input.reset(start_position);
+            input.reset(&start);
             Ok((a, 0))
         }
     }

--- a/src/rules_and_declarations.rs
+++ b/src/rules_and_declarations.rs
@@ -414,8 +414,12 @@ where P: QualifiedRuleParser<'i, QualifiedRule = R, Error = E> +
     })
 }
 
+/// A parse error with details of where it occured
 pub struct PreciseParseError<'i, E: 'i> {
+    /// Error details
     pub error: ParseError<'i, E>,
+
+    /// The start and end position
     pub span: Range<SourcePosition>,
 }
 

--- a/src/rules_and_declarations.rs
+++ b/src/rules_and_declarations.rs
@@ -5,10 +5,9 @@
 // https://drafts.csswg.org/css-syntax/#parsing
 
 use cow_rc_str::CowRcStr;
-use parser::{parse_until_before, parse_until_after, parse_nested_block};
+use parser::{parse_until_before, parse_until_after, parse_nested_block, ParserState};
 use std::ascii::AsciiExt;
-use std::ops::Range;
-use super::{Token, Parser, Delimiter, SourcePosition, ParseError, BasicParseError};
+use super::{Token, Parser, Delimiter, ParseError, BasicParseError, SourceLocation};
 
 
 /// Parse `!important`.
@@ -238,7 +237,7 @@ where P: DeclarationParser<'i, Declaration = I, Error = E> +
 
     fn next(&mut self) -> Option<Result<I, PreciseParseError<'i, E>>> {
         loop {
-            let start_position = self.input.position();
+            let start = self.input.state();
             // FIXME: remove intermediate variable when lifetimes are non-lexical
             let ident = match self.input.next_including_whitespace_and_comments() {
                 Ok(&Token::WhiteSpace(_)) | Ok(&Token::Comment(_)) | Ok(&Token::Semicolon) => continue,
@@ -259,19 +258,21 @@ where P: DeclarationParser<'i, Declaration = I, Error = E> +
                         })
                     }.map_err(|e| PreciseParseError {
                         error: e,
-                        span: start_position..self.input.position()
+                        slice: self.input.slice_from(start.position()),
+                        location: start.source_location(),
                     }))
                 }
                 Ok(Err(name)) => {
                     // At-keyword
-                    return Some(parse_at_rule(start_position, name, self.input, &mut self.parser))
+                    return Some(parse_at_rule(&start, name, self.input, &mut self.parser))
                 }
                 Err(token) => {
                     return Some(self.input.parse_until_after(Delimiter::Semicolon,
                                                              |_| Err(ParseError::Basic(BasicParseError::UnexpectedToken(token.clone()))))
                                 .map_err(|e| PreciseParseError {
                                     error: e,
-                                    span: start_position..self.input.position()
+                                    slice: self.input.slice_from(start.position()),
+                                    location: start.source_location(),
                                 }))
                 }
             }
@@ -341,7 +342,7 @@ where P: QualifiedRuleParser<'i, QualifiedRule = R, Error = E> +
 
     fn next(&mut self) -> Option<Result<R, PreciseParseError<'i, E>>> {
         loop {
-            let start_position = self.input.position();
+            let start = self.input.state();
             // FIXME: remove intermediate variable when lifetimes are non-lexical
             let at_keyword = match self.input.next_including_whitespace_and_comments() {
                 Ok(&Token::WhiteSpace(_)) | Ok(&Token::Comment(_)) => continue,
@@ -357,15 +358,16 @@ where P: QualifiedRuleParser<'i, QualifiedRule = R, Error = E> +
                     let delimiters = Delimiter::Semicolon | Delimiter::CurlyBracketBlock;
                     let _: Result<(), ParseError<()>> = self.input.parse_until_after(delimiters, |_| Ok(()));
                 } else {
-                    return Some(parse_at_rule(start_position, name.clone(), self.input, &mut self.parser))
+                    return Some(parse_at_rule(&start, name.clone(), self.input, &mut self.parser))
                 }
             } else {
                 self.any_rule_so_far = true;
-                self.input.reset(start_position);
+                self.input.reset(&start);
                 return Some(parse_qualified_rule(self.input, &mut self.parser)
                             .map_err(|e| PreciseParseError {
                                 error: e,
-                                span: start_position..self.input.position()
+                                slice: self.input.slice_from(start.position()),
+                                location: start.source_location(),
                             }))
             }
         }
@@ -379,13 +381,15 @@ pub fn parse_one_declaration<'i, 't, P, E>(input: &mut Parser<'i, 't>, parser: &
                                                      PreciseParseError<'i, E>>
                                            where P: DeclarationParser<'i, Error = E> {
     let start_position = input.position();
+    let start_location = input.current_source_location();
     input.parse_entirely(|input| {
         let name = input.expect_ident()?.clone();
         input.expect_colon()?;
         parser.parse_value(name, input)
     }).map_err(|e| PreciseParseError {
         error: e,
-        span: start_position..input.position()
+        slice: input.slice_from(start_position),
+        location: start_location,
     })
 }
 
@@ -397,7 +401,7 @@ where P: QualifiedRuleParser<'i, QualifiedRule = R, Error = E> +
          AtRuleParser<'i, AtRule = R, Error = E> {
     input.parse_entirely(|input| {
         loop {
-            let start_position = input.position();
+            let start = input.state();
             // FIXME: remove intermediate variable when lifetimes are non-lexical
             let at_keyword = match *input.next_including_whitespace_and_comments()? {
                 Token::WhiteSpace(_) | Token::Comment(_) => continue,
@@ -405,9 +409,9 @@ where P: QualifiedRuleParser<'i, QualifiedRule = R, Error = E> +
                 _ => None
             };
             if let Some(name) = at_keyword {
-                return parse_at_rule(start_position, name, input, parser).map_err(|e| e.error)
+                return parse_at_rule(&start, name, input, parser).map_err(|e| e.error)
             } else {
-                input.reset(start_position);
+                input.reset(&start);
                 return parse_qualified_rule(input, parser)
             }
         }
@@ -419,11 +423,14 @@ pub struct PreciseParseError<'i, E: 'i> {
     /// Error details
     pub error: ParseError<'i, E>,
 
-    /// The start and end position
-    pub span: Range<SourcePosition>,
+    /// The relevant slice of the input.
+    pub slice: &'i str,
+
+    /// The line number and column number of the start of the relevant input slice.
+    pub location: SourceLocation,
 }
 
-fn parse_at_rule<'i: 't, 't, P, E>(start_position: SourcePosition, name: CowRcStr<'i>,
+fn parse_at_rule<'i: 't, 't, P, E>(start: &ParserState, name: CowRcStr<'i>,
                                    input: &mut Parser<'i, 't>, parser: &mut P)
                                    -> Result<<P as AtRuleParser<'i>>::AtRule, PreciseParseError<'i, E>>
                                    where P: AtRuleParser<'i, Error = E> {
@@ -438,7 +445,8 @@ fn parse_at_rule<'i: 't, 't, P, E>(start_position: SourcePosition, name: CowRcSt
                 Ok(&Token::Semicolon) | Err(_) => Ok(rule),
                 Ok(&Token::CurlyBracketBlock) => Err(PreciseParseError {
                     error: ParseError::Basic(BasicParseError::UnexpectedToken(Token::CurlyBracketBlock)),
-                    span: start_position..input.position(),
+                    slice: input.slice_from(start.position()),
+                    location: start.source_location(),
                 }),
                 Ok(_) => unreachable!()
             }
@@ -450,16 +458,19 @@ fn parse_at_rule<'i: 't, 't, P, E>(start_position: SourcePosition, name: CowRcSt
                     parse_nested_block::<'i, 't, _, _, _>(input, move |input| parser.parse_block(prelude, input))
                         .map_err(|e| PreciseParseError {
                             error: e,
-                            span: start_position..input.position(),
+                            slice: input.slice_from(start.position()),
+                            location: start.source_location(),
                         })
                 }
                 Ok(&Token::Semicolon) => Err(PreciseParseError {
                     error: ParseError::Basic(BasicParseError::UnexpectedToken(Token::Semicolon)),
-                    span: start_position..input.position()
+                    slice: input.slice_from(start.position()),
+                    location: start.source_location(),
                 }),
                 Err(e) => Err(PreciseParseError {
                     error: ParseError::Basic(e),
-                    span: start_position..input.position(),
+                    slice: input.slice_from(start.position()),
+                    location: start.source_location(),
                 }),
                 Ok(_) => unreachable!()
             }
@@ -472,7 +483,8 @@ fn parse_at_rule<'i: 't, 't, P, E>(start_position: SourcePosition, name: CowRcSt
                     parse_nested_block::<'i, 't, _, _, _>(input, move |input| parser.parse_block(prelude, input))
                         .map_err(|e| PreciseParseError {
                             error: e,
-                            span: start_position..input.position(),
+                            slice: input.slice_from(start.position()),
+                            location: start.source_location(),
                         })
                 }
                 _ => unreachable!()
@@ -486,7 +498,8 @@ fn parse_at_rule<'i: 't, 't, P, E>(start_position: SourcePosition, name: CowRcSt
             };
             Err(PreciseParseError {
                 error: error,
-                span: start_position..end_position,
+                slice: input.slice(start.position()..end_position),
+                location: start.source_location(),
             })
         }
     }

--- a/src/size_of_tests.rs
+++ b/src/size_of_tests.rs
@@ -31,7 +31,18 @@ macro_rules! size_of_test {
     }
 }
 
-// These assume 64-bit
+// Some of these assume 64-bit
 size_of_test!(token, Token, 32);
 size_of_test!(std_cow_str, Cow<'static, str>, 32);
 size_of_test!(cow_rc_str, CowRcStr, 16);
+
+size_of_test!(tokenizer, ::tokenizer::Tokenizer, 48);
+size_of_test!(parser_input, ::parser::ParserInput, 104);
+size_of_test!(parser, ::parser::Parser, 16);
+size_of_test!(tokenizer_source_position, ::tokenizer::SourcePosition, 8);
+size_of_test!(source_position, ::parser::SourcePosition, 16);
+size_of_test!(source_location, ::SourceLocation, 8);
+
+size_of_test!(basic_parse_error, ::BasicParseError, 40);
+size_of_test!(parse_error_lower_bound, ::ParseError<()>, 48);
+size_of_test!(precise_parse_error_lower_bound, ::PreciseParseError<()>, 80);

--- a/src/size_of_tests.rs
+++ b/src/size_of_tests.rs
@@ -36,13 +36,12 @@ size_of_test!(token, Token, 32);
 size_of_test!(std_cow_str, Cow<'static, str>, 32);
 size_of_test!(cow_rc_str, CowRcStr, 16);
 
-size_of_test!(tokenizer, ::tokenizer::Tokenizer, 48);
-size_of_test!(parser_input, ::parser::ParserInput, 104);
+size_of_test!(tokenizer, ::tokenizer::Tokenizer, 40);
+size_of_test!(parser_input, ::parser::ParserInput, 112);
 size_of_test!(parser, ::parser::Parser, 16);
-size_of_test!(tokenizer_source_position, ::tokenizer::SourcePosition, 8);
-size_of_test!(source_position, ::parser::SourcePosition, 16);
-size_of_test!(source_location, ::SourceLocation, 8);
+size_of_test!(source_position, ::SourcePosition, 8);
+size_of_test!(parser_state, ::ParserState, 24);
 
 size_of_test!(basic_parse_error, ::BasicParseError, 40);
 size_of_test!(parse_error_lower_bound, ::ParseError<()>, 48);
-size_of_test!(precise_parse_error_lower_bound, ::PreciseParseError<()>, 80);
+size_of_test!(precise_parse_error_lower_bound, ::PreciseParseError<()>, 72);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -379,6 +379,14 @@ impl<'a> Tokenizer<'a> {
         self.input[self.position..].chars().next().unwrap()
     }
 
+    fn seen_newline(&mut self, is_cr: bool) {
+        if is_cr && self.next_byte() == Some(/* LF */ b'\n') {
+            return
+        }
+        self.current_line_start_position = self.position;
+        self.current_line_number += 1;
+    }
+
     #[inline]
     fn has_newline_at(&self, offset: usize) -> bool {
         self.position + offset < self.input.len() &&
@@ -420,16 +428,14 @@ fn next_token<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, ()> {
     }
     let b = tokenizer.next_byte_unchecked();
     let token = match_byte! { b,
-        b'\t' | b'\n' | b' ' | b'\r' | b'\x0C' => {
-            let start_position = tokenizer.position();
-            tokenizer.advance(1);
-            while !tokenizer.is_eof() {
-                match tokenizer.next_byte_unchecked() {
-                    b' ' | b'\t' | b'\n' | b'\r' | b'\x0C' => tokenizer.advance(1),
-                    _ => break,
-                }
-            }
-            WhiteSpace(tokenizer.slice_from(start_position))
+        b' ' | b'\t' => {
+            consume_whitespace(tokenizer, false, false)
+        },
+        b'\n' | b'\x0C' => {
+            consume_whitespace(tokenizer, true, false)
+        },
+        b'\r' => {
+            consume_whitespace(tokenizer, true, true)
         },
         b'"' => { consume_string(tokenizer, false) },
         b'#' => {
@@ -501,21 +507,7 @@ fn next_token<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, ()> {
         }
         b'/' => {
             if tokenizer.starts_with(b"/*") {
-                tokenizer.advance(2);  // consume "/*"
-                let start_position = tokenizer.position();
-                let content;
-                match tokenizer.input[tokenizer.position..].find("*/") {
-                    Some(offset) => {
-                        tokenizer.advance(offset);
-                        content = tokenizer.slice_from(start_position);
-                        tokenizer.advance(2);
-                    }
-                    None => {
-                        tokenizer.position = tokenizer.input.len();
-                        content = tokenizer.slice_from(start_position);
-                    }
-                }
-                Comment(content)
+                Comment(consume_comment(tokenizer))
             } else {
                 tokenizer.advance(1);
                 Delim('/')
@@ -572,6 +564,64 @@ fn next_token<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, ()> {
     Ok(token)
 }
 
+
+fn consume_whitespace<'a>(tokenizer: &mut Tokenizer<'a>, newline: bool, is_cr: bool) -> Token<'a> {
+    let start_position = tokenizer.position();
+    tokenizer.advance(1);
+    if newline {
+        tokenizer.seen_newline(is_cr)
+    }
+    while !tokenizer.is_eof() {
+        let b = tokenizer.next_byte_unchecked();
+        match_byte! { b,
+            b' ' | b'\t' => {
+                tokenizer.advance(1);
+            }
+            b'\n' | b'\x0C' => {
+                tokenizer.advance(1);
+                tokenizer.seen_newline(false);
+            }
+            b'\r' => {
+                tokenizer.advance(1);
+                tokenizer.seen_newline(true);
+            }
+            _ => {
+                break
+            }
+        }
+    }
+    WhiteSpace(tokenizer.slice_from(start_position))
+}
+
+
+fn consume_comment<'a>(tokenizer: &mut Tokenizer<'a>) -> &'a str {
+    tokenizer.advance(2);  // consume "/*"
+    let start_position = tokenizer.position();
+    while !tokenizer.is_eof() {
+        match_byte! { tokenizer.next_byte_unchecked(),
+            b'*' => {
+                let end_position = tokenizer.position();
+                tokenizer.advance(1);
+                if tokenizer.next_byte() == Some(b'/') {
+                    tokenizer.advance(1);
+                    return tokenizer.slice(start_position..end_position)
+                }
+            }
+            b'\n' | b'\x0C' => {
+                tokenizer.advance(1);
+                tokenizer.seen_newline(false);
+            }
+            b'\r' => {
+                tokenizer.advance(1);
+                tokenizer.seen_newline(true);
+            }
+            _ => {
+                tokenizer.advance(1);
+            }
+        }
+    }
+    tokenizer.slice_from(start_position)
+}
 
 fn consume_string<'a>(tokenizer: &mut Tokenizer<'a>, single_quote: bool) -> Token<'a> {
     match consume_quoted_string(tokenizer, single_quote) {
@@ -649,12 +699,19 @@ fn consume_quoted_string<'a>(tokenizer: &mut Tokenizer<'a>, single_quote: bool)
                 if !tokenizer.is_eof() {
                     match tokenizer.next_byte_unchecked() {
                         // Escaped newline
-                        b'\n' | b'\x0C' => tokenizer.advance(1),
+                        b'\n' | b'\x0C' => {
+                            tokenizer.advance(1);
+                            tokenizer.seen_newline(false);
+                        }
                         b'\r' => {
                             tokenizer.advance(1);
                             if tokenizer.next_byte() == Some(b'\n') {
                                 tokenizer.advance(1);
                             }
+                            // `is_cr = true` is useful to skip \r when the next iteration
+                            // of a loop will call `seen_newline` again for the following \n.
+                            // In this case we’re consuming both in this iteration, so passing `false`.
+                            tokenizer.seen_newline(false);
                         }
                         // This pushes one well-formed code point
                         _ => consume_escape_and_write(tokenizer, &mut string_bytes)
@@ -921,24 +978,57 @@ unsafe fn from_utf8_release_unchecked(string_bytes: Vec<u8>) -> String {
 
 fn consume_unquoted_url<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, ()> {
     // This is only called after "url(", so the current position is a code point boundary.
-    for (offset, c) in tokenizer.input[tokenizer.position..].bytes().enumerate() {
-        match_byte! { c,
-            b' ' | b'\t' | b'\n' | b'\r' | b'\x0C' => {},
+    let start_position = tokenizer.position;
+    let from_start = &tokenizer.input[tokenizer.position..];
+    let mut newlines = 0;
+    let mut last_newline = 0;
+    let mut found_printable_char = false;
+    let mut iter = from_start.bytes().enumerate();
+    loop {
+        let (offset, b) = match iter.next() {
+            Some(item) => item,
+            None => {
+                tokenizer.position = tokenizer.input.len();
+                break
+            }
+        };
+        match_byte! { b,
+            b' ' | b'\t' => {},
+            b'\n' | b'\x0C' => {
+                newlines += 1;
+                last_newline = offset;
+            }
+            b'\r' => {
+                if from_start.as_bytes().get(offset + 1) != Some(&b'\n') {
+                    newlines += 1;
+                    last_newline = offset;
+                }
+            }
             b'"' | b'\'' => { return Err(()) },  // Do not advance
             b')' => {
                 tokenizer.advance(offset + 1);
-                return Ok(UnquotedUrl("".into()));
+                break
             }
             _ => {
                 tokenizer.advance(offset);
-                // This function only consumed ASCII (whitespace) bytes,
-                // so the current position is a code point boundary.
-                return Ok(consume_unquoted_url_internal(tokenizer))
+                found_printable_char = true;
+                break
             }
         }
     }
-    tokenizer.position = tokenizer.input.len();
-    return Ok(UnquotedUrl("".into()));
+
+    if newlines > 0 {
+        tokenizer.current_line_number += newlines;
+        tokenizer.current_line_start_position = start_position + last_newline + 1;
+    }
+
+    if found_printable_char {
+        // This function only consumed ASCII (whitespace) bytes,
+        // so the current position is a code point boundary.
+        return Ok(consume_unquoted_url_internal(tokenizer))
+    } else {
+        return Ok(UnquotedUrl("".into()))
+    }
 
     fn consume_unquoted_url_internal<'a>(tokenizer: &mut Tokenizer<'a>) -> Token<'a> {
         // This function is only called with start_pos at a code point boundary.
@@ -951,7 +1041,6 @@ fn consume_unquoted_url<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, 
             match_byte! { tokenizer.next_byte_unchecked(),
                 b' ' | b'\t' | b'\n' | b'\r' | b'\x0C' => {
                     let value = tokenizer.slice_from(start_pos);
-                    tokenizer.advance(1);
                     return consume_url_end(tokenizer, start_pos, value.into())
                 }
                 b')' => {
@@ -974,7 +1063,7 @@ fn consume_unquoted_url<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, 
                     break
                 }
                 _ => {
-                    tokenizer.consume_byte();
+                    tokenizer.advance(1);
                 }
             }
         }
@@ -983,6 +1072,7 @@ fn consume_unquoted_url<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, 
                 b' ' | b'\t' | b'\n' | b'\r' | b'\x0C' => {
                     // string_bytes is well-formed UTF-8, see other comments.
                     let string = unsafe { from_utf8_release_unchecked(string_bytes) }.into();
+                    tokenizer.position -= 1;
                     return consume_url_end(tokenizer, start_pos, string)
                 }
                 b')' => {
@@ -1020,8 +1110,16 @@ fn consume_unquoted_url<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, 
                            -> Token<'a> {
         while !tokenizer.is_eof() {
             match_byte! { tokenizer.consume_byte(),
-                b' ' | b'\t' | b'\n' | b'\r' | b'\x0C' => {},
-                b')' => { break },
+                b')' => {
+                    break
+                }
+                b' ' | b'\t' => {}
+                b'\n' | b'\x0C' => {
+                    tokenizer.seen_newline(false);
+                }
+                b'\r' => {
+                    tokenizer.seen_newline(true);
+                }
                 _ => {
                     return consume_bad_url(tokenizer, start_pos);
                 }
@@ -1034,11 +1132,19 @@ fn consume_unquoted_url<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, 
         // Consume up to the closing )
         while !tokenizer.is_eof() {
             match_byte! { tokenizer.consume_byte(),
-                b')' => { break },
+                b')' => {
+                    break
+                }
                 b'\\' => {
                     if matches!(tokenizer.next_byte(), Some(b')') | Some(b'\\')) {
                         tokenizer.advance(1); // Skip an escaped ')' or '\'
                     }
+                }
+                b'\n' | b'\x0C' => {
+                    tokenizer.seen_newline(false);
+                }
+                b'\r' => {
+                    tokenizer.seen_newline(true);
                 }
                 _ => {},
             }
@@ -1080,15 +1186,22 @@ fn consume_escape(tokenizer: &mut Tokenizer) -> char {
         b'0'...b'9' | b'A'...b'F' | b'a'...b'f' => {
             let (c, _) = consume_hex_digits(tokenizer);
             if !tokenizer.is_eof() {
-                match tokenizer.next_byte_unchecked() {
-                    b' ' | b'\t' | b'\n' | b'\x0C' => tokenizer.advance(1),
+                match_byte! { tokenizer.next_byte_unchecked(),
+                    b' ' | b'\t' => {
+                        tokenizer.advance(1)
+                    }
+                    b'\n' | b'\x0C' => {
+                        tokenizer.advance(1);
+                        tokenizer.seen_newline(false)
+                    }
                     b'\r' => {
                         tokenizer.advance(1);
                         if !tokenizer.is_eof() && tokenizer.next_byte_unchecked() == b'\n' {
                             tokenizer.advance(1);
                         }
+                        tokenizer.seen_newline(false)
                     }
-                    _ => ()
+                    _ => {}
                 }
             }
             static REPLACEMENT_CHAR: char = '\u{FFFD}';

--- a/src/unicode_range.rs
+++ b/src/unicode_range.rs
@@ -68,12 +68,12 @@ fn parse_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), BasicParseErro
             parse_question_marks(input)
         }
         Token::Number { .. } => {
-            let after_number = input.position();
+            let after_number = input.state();
             match input.next_including_whitespace() {
                 Ok(&Token::Delim('?')) => parse_question_marks(input),
                 Ok(&Token::Dimension { .. }) => {}
                 Ok(&Token::Number { .. }) => {}
-                _ => input.reset(after_number)
+                _ => input.reset(&after_number)
             }
         }
         t => return Err(BasicParseError::UnexpectedToken(t))
@@ -84,11 +84,11 @@ fn parse_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), BasicParseErro
 /// Consume as many '?' as possible
 fn parse_question_marks(input: &mut Parser) {
     loop {
-        let position = input.position();
+        let start = input.state();
         match input.next_including_whitespace() {
             Ok(&Token::Delim('?')) => {}
             _ => {
-                input.reset(position);
+                input.reset(&start);
                 return
             }
         }


### PR DESCRIPTION
Before this PR, the `source_location` and `current_source_location` iterated (again) through input bytes separately from tokenization in order to count newline characters and determine the line number of some piece of a stylesheet.

This PR makes this counting happen during tokenization instead, where we already have a pass looking at every bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/177)
<!-- Reviewable:end -->
