### PR TITLE
Fix an off-by-one error in CDC skipping

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -971,6 +971,15 @@ fn parser_maintains_current_line() {
 }
 
 #[test]
+fn cdc_regression_test() {
+    let mut input = ParserInput::new("-->x");
+    let mut parser = Parser::new(&mut input);
+    parser.skip_cdc_and_cdo();
+    assert_eq!(parser.next(), Ok(&Token::Ident("x".into())));
+    assert_eq!(parser.next(), Err(BasicParseError::EndOfInput));
+}
+
+#[test]
 fn parse_entirely_reports_first_error() {
     #[derive(PartialEq, Debug)]
     enum E { Foo }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -470,7 +470,7 @@ impl<'a> Tokenizer<'a> {
                 }
                 b'-' => {
                     if self.starts_with(b"-->") {
-                        self.advance(4)
+                        self.advance(3)
                     } else {
                         return
                     }


### PR DESCRIPTION
skip_cdc_and_cdo had an off-by-one error when trying to skip the CDC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/182)
<!-- Reviewable:end -->
