### PR TITLE
Provide ParserInput::new_with_line_number_offset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.19.4"
+version = "0.19.5"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -101,6 +101,15 @@ impl<'i> ParserInput<'i> {
         }
     }
 
+    /// Create a new input for a parser.  Line numbers in locations
+    /// are offset by the given value.
+    pub fn new_with_line_number_offset(input: &'i str, first_line_number: u32) -> ParserInput<'i> {
+        ParserInput {
+            tokenizer: Tokenizer::with_first_line_number(input, first_line_number),
+            cached_token: None,
+        }
+    }
+
     #[inline]
     fn cached_token_ref(&self) -> &Token<'i> {
         &self.cached_token.as_ref().unwrap().token

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -971,6 +971,20 @@ fn parser_maintains_current_line() {
 }
 
 #[test]
+fn parser_with_line_number_offset() {
+    let mut input = ParserInput::new_with_line_number_offset("ident\nident", 72);
+    let mut parser = Parser::new(&mut input);
+    assert_eq!(parser.current_source_location(), SourceLocation { line: 72, column: 0 });
+    assert_eq!(parser.next_including_whitespace_and_comments(), Ok(&Token::Ident("ident".into())));
+    assert_eq!(parser.current_source_location(), SourceLocation { line: 72, column: 5 });
+    assert_eq!(parser.next_including_whitespace_and_comments(),
+               Ok(&Token::WhiteSpace("\n".into())));
+    assert_eq!(parser.current_source_location(), SourceLocation { line: 73, column: 0 });
+    assert_eq!(parser.next_including_whitespace_and_comments(), Ok(&Token::Ident("ident".into())));
+    assert_eq!(parser.current_source_location(), SourceLocation { line: 73, column: 5 });
+}
+
+#[test]
 fn cdc_regression_test() {
     let mut input = ParserInput::new("-->x");
     let mut parser = Parser::new(&mut input);


### PR DESCRIPTION
This patch adds ParserInput::new_with_line_number_offset, a new
constructor that calls Tokenizer::with_first_line_number.  Servo has its
own code for tracking the initial line number, but that code can be
replaced by this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/184)
<!-- Reviewable:end -->
