### PR TITLE
Fix interaction of skip_whitespace and nested blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.19.4"
+version = "0.19.5"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -291,10 +291,8 @@ impl<'i: 't, 't> Parser<'i, 't> {
     /// Advance the input until the next token that’s not whitespace or a comment.
     #[inline]
     pub fn skip_whitespace(&mut self) {
-        // If we just consumed `{`, `[`, `(`, or `function(`, leave whitespace
-        // or comments inside the block or function up to the nested parser.
-        if self.at_start_of.is_some() {
-            return
+        if let Some(block_type) = self.at_start_of.take() {
+            consume_until_end_of_block(block_type, &mut self.input.tokenizer);
         }
 
         self.input.tokenizer.skip_whitespace()
@@ -302,6 +300,10 @@ impl<'i: 't, 't> Parser<'i, 't> {
 
     #[inline]
     pub(crate) fn skip_cdc_and_cdo(&mut self) {
+        if let Some(block_type) = self.at_start_of.take() {
+            consume_until_end_of_block(block_type, &mut self.input.tokenizer);
+        }
+
         self.input.tokenizer.skip_cdc_and_cdo()
     }
 


### PR DESCRIPTION
This fixes (at least some of) the test failures at https://github.com/servo/servo/pull/18171

In code like this:

```css
unsupported selector ! { stuff }
valid selector { color: green }
```

`rules_and_declarations::parse_qualified_rule` would leave the parser just after the first `{` with `Parser::at_start_of == Some(BlockType::CurlyBracket)`. The latter means that, unless `Parser::parse_nested_block` is called, the parser needs to skip over this block until the matching `}` before doing anything else. This PR makes `Parser::skip_whitespace` and `Parser::skip_cdc_and_cdo` (both added recently in https://github.com/servo/rust-cssparser/pull/181) take care of `Parser::at_start_of` correctly the same way `Parser::next` does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/185)
<!-- Reviewable:end -->
