### PR TITLE
Use a SmallVec instead of Vec in consume_until_end_of_block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ matches = "0.1"
 phf = "0.7"
 procedural-masquerade = {path = "./procedural-masquerade", version = "0.1"}
 serde = {version = "1.0", optional = true}
+smallvec = "0.4.3"
 
 [build-dependencies]
 syn = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ extern crate dtoa_short;
 #[cfg(test)] extern crate rustc_serialize;
 #[cfg(feature = "serde")] extern crate serde;
 #[cfg(feature = "heapsize")] #[macro_use] extern crate heapsize;
+extern crate smallvec;
 
 pub use cssparser_macros::*;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use cow_rc_str::CowRcStr;
+use smallvec::SmallVec;
 use std::ops::Range;
 use std::ascii::AsciiExt;
 use std::ops::BitOr;
@@ -858,7 +859,8 @@ pub fn parse_nested_block<'i: 't, 't, F, T, E>(parser: &mut Parser<'i, 't>, pars
 }
 
 fn consume_until_end_of_block(block_type: BlockType, tokenizer: &mut Tokenizer) {
-    let mut stack = vec![block_type];
+    let mut stack = SmallVec::<[BlockType; 16]>::new();
+    stack.push(block_type);
 
     // FIXME: have a special-purpose tokenizer method for this that does less work.
     while let Ok(ref token) = tokenizer.next() {


### PR DESCRIPTION
… to avoid allocating in common cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/186)
<!-- Reviewable:end -->
