### PR TITLE
parser: Remove ability to look for viewport percentages.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.19.6"
+version = "0.20.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -353,20 +353,6 @@ impl<'i: 't, 't> Parser<'i, 't> {
         self.input.tokenizer.seen_var_functions()
     }
 
-    /// Start looking for viewport percentage lengths. (See the `seen_viewport_percentages`
-    /// method.)
-    #[inline]
-    pub fn look_for_viewport_percentages(&mut self) {
-        self.input.tokenizer.look_for_viewport_percentages()
-    }
-
-    /// Return whether a `vh`, `vw`, `vmin`, or `vmax` dimension has been seen by the tokenizer
-    /// since `look_for_viewport_percentages` was called, and stop looking.
-    #[inline]
-    pub fn seen_viewport_percentages(&mut self) -> bool {
-        self.input.tokenizer.seen_viewport_percentages()
-    }
-
     /// Execute the given closure, passing it the parser.
     /// If the result (returned unchanged) is `Err`,
     /// the internal state of the parser  (including position within the input)
@@ -445,7 +431,6 @@ impl<'i: 't, 't> Parser<'i, 't> {
             if cached_token.start_position == token_start_position => {
                 self.input.tokenizer.reset(&cached_token.end_state);
                 match cached_token.token {
-                    Token::Dimension { ref unit, .. } => self.input.tokenizer.see_dimension(unit),
                     Token::Function(ref name) => self.input.tokenizer.see_function(name),
                     _ => {}
                 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -208,7 +208,6 @@ pub struct Tokenizer<'a> {
     current_line_start_position: usize,
     current_line_number: u32,
     var_functions: SeenStatus,
-    viewport_percentages: SeenStatus,
     source_map_url: Option<&'a str>,
 }
 
@@ -234,7 +233,6 @@ impl<'a> Tokenizer<'a> {
             current_line_start_position: 0,
             current_line_number: first_line_number,
             var_functions: SeenStatus::DontCare,
-            viewport_percentages: SeenStatus::DontCare,
             source_map_url: None,
         }
     }
@@ -256,30 +254,6 @@ impl<'a> Tokenizer<'a> {
         if self.var_functions == SeenStatus::LookingForThem {
             if name.eq_ignore_ascii_case("var") {
                 self.var_functions = SeenStatus::SeenAtLeastOne;
-            }
-        }
-    }
-
-    #[inline]
-    pub fn look_for_viewport_percentages(&mut self) {
-        self.viewport_percentages = SeenStatus::LookingForThem;
-    }
-
-    #[inline]
-    pub fn seen_viewport_percentages(&mut self) -> bool {
-        let seen = self.viewport_percentages == SeenStatus::SeenAtLeastOne;
-        self.viewport_percentages = SeenStatus::DontCare;
-        seen
-    }
-
-    #[inline]
-    pub fn see_dimension(&mut self, unit: &str) {
-        if self.viewport_percentages == SeenStatus::LookingForThem {
-            if unit.eq_ignore_ascii_case("vh") ||
-               unit.eq_ignore_ascii_case("vw") ||
-               unit.eq_ignore_ascii_case("vmin") ||
-               unit.eq_ignore_ascii_case("vmax") {
-                   self.viewport_percentages = SeenStatus::SeenAtLeastOne;
             }
         }
     }
@@ -1045,7 +1019,6 @@ fn consume_numeric<'a>(tokenizer: &mut Tokenizer<'a>) -> Token<'a> {
     let value = value as f32;
     if is_ident_start(tokenizer) {
         let unit = consume_name(tokenizer);
-        tokenizer.see_dimension(&unit);
         Dimension {
             value: value,
             int_value: int_value,


### PR DESCRIPTION
The only user of it is going away in servo/servo#18267.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/187)
<!-- Reviewable:end -->
