### PR TITLE
Avoid array overallocation when parsing background-image property

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.20.1"
+version = "0.20.2"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"


### PR DESCRIPTION
Part 3 of the fix for Gecko bug 1397614 <https://bugzilla.mozilla.org/show_bug.cgi?id=1397614>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/195)
<!-- Reviewable:end -->
