### PR TITLE
Preserve sourceURL comment in parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.21.0"
+version = "0.21.1"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -291,6 +291,15 @@ impl<'i: 't, 't> Parser<'i, 't> {
         self.input.tokenizer.current_source_map_url()
     }
 
+    /// The source URL, if known.
+    ///
+    /// The source URL is extracted from a specially formatted
+    /// comment.  The last such comment is used, so this value may
+    /// change as parsing proceeds.
+    pub fn current_source_url(&self) -> Option<&str> {
+        self.input.tokenizer.current_source_url()
+    }
+
     /// Return the current internal state of the parser (including position within the input).
     ///
     /// This state can later be restored with the `Parser::reset` method.

--- a/src/size_of_tests.rs
+++ b/src/size_of_tests.rs
@@ -36,8 +36,8 @@ size_of_test!(token, Token, 32);
 size_of_test!(std_cow_str, Cow<'static, str>, 32);
 size_of_test!(cow_rc_str, CowRcStr, 16);
 
-size_of_test!(tokenizer, ::tokenizer::Tokenizer, 56);
-size_of_test!(parser_input, ::parser::ParserInput, 128);
+size_of_test!(tokenizer, ::tokenizer::Tokenizer, 72);
+size_of_test!(parser_input, ::parser::ParserInput, 144);
 size_of_test!(parser, ::parser::Parser, 16);
 size_of_test!(source_position, ::SourcePosition, 8);
 size_of_test!(parser_state, ::ParserState, 24);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1030,7 +1030,7 @@ fn parse_entirely_reports_first_error() {
 }
 
 #[test]
-fn parse_comments() {
+fn parse_sourcemapping_comments() {
     let tests = vec![
         ("/*# sourceMappingURL=here*/", Some("here")),
         ("/*# sourceMappingURL=here  */", Some("here")),
@@ -1051,6 +1051,31 @@ fn parse_comments() {
         while let Ok(_) = parser.next_including_whitespace() {
         }
         assert_eq!(parser.current_source_map_url(), test.1);
+    }
+}
+
+#[test]
+fn parse_sourceurl_comments() {
+    let tests = vec![
+        ("/*# sourceURL=here*/", Some("here")),
+        ("/*# sourceURL=here  */", Some("here")),
+        ("/*@ sourceURL=here*/", Some("here")),
+        ("/*@ sourceURL=there*/ /*# sourceURL=here*/", Some("here")),
+        ("/*# sourceURL=here there  */", Some("here")),
+        ("/*# sourceURL=  here  */", Some("")),
+        ("/*# sourceURL=*/", Some("")),
+        ("/*# sourceMappingUR=here  */", None),
+        ("/*! sourceURL=here  */", None),
+        ("/*# sourceURL = here  */", None),
+        ("/*   # sourceURL=here   */", None)
+    ];
+
+    for test in tests {
+        let mut input = ParserInput::new(test.0);
+        let mut parser = Parser::new(&mut input);
+        while let Ok(_) = parser.next_including_whitespace() {
+        }
+        assert_eq!(parser.current_source_url(), test.1);
     }
 }
 


### PR DESCRIPTION
In addition to the sourceMappingURL comment, there is a second special
comment, "sourceURL", that can be used to set the "display name" of a
style sheet for developer tools.  This name is also used as the base
URL for the source-map URL resolution algorithm.  sourceURL is
described here:
https://blog.getfirebug.com/2009/08/11/give-your-eval-a-name-with-sourceurl/
The relevant Firefox bug is here:
https://bugzilla.mozilla.org/show_bug.cgi?id=880831

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/197)
<!-- Reviewable:end -->
