### PR TITLE
Include a SourceLocation in all error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.21.3"
+version = "0.22.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,13 +86,14 @@ pub use cssparser_macros::*;
 pub use tokenizer::{Token, SourcePosition, SourceLocation};
 pub use rules_and_declarations::{parse_important};
 pub use rules_and_declarations::{DeclarationParser, DeclarationListParser, parse_one_declaration};
-pub use rules_and_declarations::{RuleListParser, parse_one_rule, PreciseParseError};
+pub use rules_and_declarations::{RuleListParser, parse_one_rule};
 pub use rules_and_declarations::{AtRuleType, QualifiedRuleParser, AtRuleParser};
 pub use from_bytes::{stylesheet_encoding, EncodingSupport};
 pub use color::{RGBA, Color, parse_color_keyword};
 pub use nth::parse_nth;
 pub use serializer::{ToCss, CssStringWriter, serialize_identifier, serialize_string, TokenSerializationType};
-pub use parser::{Parser, Delimiter, Delimiters, ParserState, ParseError, BasicParseError, ParserInput};
+pub use parser::{Parser, Delimiter, Delimiters, ParserState, ParserInput};
+pub use parser::{ParseError, ParseErrorKind, BasicParseError, BasicParseErrorKind};
 pub use unicode_range::UnicodeRange;
 pub use cow_rc_str::CowRcStr;
 

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -24,7 +24,7 @@ pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), Basic
                 "n-" => Ok(try!(parse_signless_b(input, a, -1))),
                 _ => match parse_n_dash_digits(&*unit) {
                     Ok(b) => Ok((a, b)),
-                    Err(()) => Err(BasicParseError::UnexpectedToken(Token::Ident(unit.clone())))
+                    Err(()) => Err(input.new_basic_unexpected_token_error(Token::Ident(unit.clone())))
                 }
             }
         }
@@ -44,7 +44,7 @@ pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), Basic
                     };
                     match parse_n_dash_digits(slice) {
                         Ok(b) => Ok((a, b)),
-                        Err(()) => Err(BasicParseError::UnexpectedToken(Token::Ident(value.clone())))
+                        Err(()) => Err(input.new_basic_unexpected_token_error(Token::Ident(value.clone())))
                     }
                 }
             }
@@ -57,13 +57,13 @@ pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), Basic
                     "n-" => parse_signless_b(input, 1, -1),
                     _ => match parse_n_dash_digits(&*value) {
                         Ok(b) => Ok((1, b)),
-                        Err(()) => Err(BasicParseError::UnexpectedToken(Token::Ident(value.clone())))
+                        Err(()) => Err(input.new_basic_unexpected_token_error(Token::Ident(value.clone())))
                     }
                 }
             }
-            token => Err(BasicParseError::UnexpectedToken(token)),
+            token => Err(input.new_basic_unexpected_token_error(token)),
         },
-        token => Err(BasicParseError::UnexpectedToken(token)),
+        token => Err(input.new_basic_unexpected_token_error(token)),
     }
 }
 
@@ -82,9 +82,10 @@ fn parse_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32) -> Result<(i32, i32), Bas
 }
 
 fn parse_signless_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32, b_sign: i32) -> Result<(i32, i32), BasicParseError<'i>> {
-    match *input.next()? {
+    // FIXME: remove .clone() when lifetimes are non-lexical.
+    match input.next()?.clone() {
         Token::Number { has_sign: false, int_value: Some(b), .. } => Ok((a, b_sign * b)),
-        ref token => Err(BasicParseError::UnexpectedToken(token.clone()))
+        token => Err(input.new_basic_unexpected_token_error(token))
     }
 }
 

--- a/src/rules_and_declarations.rs
+++ b/src/rules_and_declarations.rs
@@ -7,8 +7,7 @@
 use cow_rc_str::CowRcStr;
 use parser::{parse_until_before, parse_until_after, parse_nested_block, ParserState};
 use std::ascii::AsciiExt;
-use super::{Token, Parser, Delimiter, ParseError, BasicParseError, SourceLocation};
-
+use super::{Token, Parser, Delimiter, ParseError, BasicParseError, BasicParseErrorKind};
 
 /// Parse `!important`.
 ///
@@ -18,7 +17,6 @@ pub fn parse_important<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), BasicPa
     input.expect_delim('!')?;
     input.expect_ident_matching("important")
 }
-
 
 /// The return value for `AtRuleParser::parse_prelude`.
 /// Indicates whether the at-rule is expected to have a `{ /* ... */ }` block
@@ -112,7 +110,7 @@ pub trait AtRuleParser<'i> {
                                ParseError<'i, Self::Error>> {
         let _ = name;
         let _ = input;
-        Err(ParseError::Basic(BasicParseError::AtRuleInvalid(name)))
+        Err(input.new_error(BasicParseErrorKind::AtRuleInvalid(name)))
     }
 
     /// End an at-rule which doesn't have block. Return the finished
@@ -139,7 +137,7 @@ pub trait AtRuleParser<'i> {
                        -> Result<Self::AtRule, ParseError<'i, Self::Error>> {
         let _ = prelude;
         let _ = input;
-        Err(ParseError::Basic(BasicParseError::AtRuleBodyInvalid))
+        Err(input.new_error(BasicParseErrorKind::AtRuleBodyInvalid))
     }
 }
 
@@ -175,7 +173,7 @@ pub trait QualifiedRuleParser<'i> {
     fn parse_prelude<'t>(&mut self, input: &mut Parser<'i, 't>)
                          -> Result<Self::Prelude, ParseError<'i, Self::Error>> {
         let _ = input;
-        Err(ParseError::Basic(BasicParseError::QualifiedRuleInvalid))
+        Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid))
     }
 
     /// Parse the content of a `{ /* ... */ }` block for the body of the qualified rule.
@@ -187,7 +185,7 @@ pub trait QualifiedRuleParser<'i> {
                        -> Result<Self::QualifiedRule, ParseError<'i, Self::Error>> {
         let _ = prelude;
         let _ = input;
-        Err(ParseError::Basic(BasicParseError::QualifiedRuleInvalid))
+        Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid))
     }
 }
 
@@ -232,9 +230,9 @@ where P: DeclarationParser<'i, Declaration = I, Error = E> +
 impl<'i: 't, 't: 'a, 'a, I, P, E: 'i> Iterator for DeclarationListParser<'i, 't, 'a, P>
 where P: DeclarationParser<'i, Declaration = I, Error = E> +
          AtRuleParser<'i, AtRule = I, Error = E> {
-    type Item = Result<I, PreciseParseError<'i, E>>;
+    type Item = Result<I, (ParseError<'i, E>, &'i str)>;
 
-    fn next(&mut self) -> Option<Result<I, PreciseParseError<'i, E>>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             let start = self.input.state();
             // FIXME: remove intermediate variable when lifetimes are non-lexical
@@ -248,31 +246,25 @@ where P: DeclarationParser<'i, Declaration = I, Error = E> +
             match ident {
                 Ok(Ok(name)) => {
                     // Ident
-                    return Some({
+                    let result = {
                         let parser = &mut self.parser;
                         // FIXME: https://github.com/rust-lang/rust/issues/42508
                         parse_until_after::<'i, 't, _, _, _>(self.input, Delimiter::Semicolon, |input| {
                             input.expect_colon()?;
                             parser.parse_value(name, input)
                         })
-                    }.map_err(|e| PreciseParseError {
-                        error: e,
-                        slice: self.input.slice_from(start.position()),
-                        location: start.source_location(),
-                    }))
+                    };
+                    return Some(result.map_err(|e| (e, self.input.slice_from(start.position()))))
                 }
                 Ok(Err(name)) => {
                     // At-keyword
                     return Some(parse_at_rule(&start, name, self.input, &mut self.parser))
                 }
                 Err(token) => {
-                    return Some(self.input.parse_until_after(Delimiter::Semicolon,
-                                                             |_| Err(ParseError::Basic(BasicParseError::UnexpectedToken(token.clone()))))
-                                .map_err(|e| PreciseParseError {
-                                    error: e,
-                                    slice: self.input.slice_from(start.position()),
-                                    location: start.source_location(),
-                                }))
+                    let result = self.input.parse_until_after(Delimiter::Semicolon, |_| {
+                        Err(start.source_location().new_unexpected_token_error(token.clone()))
+                    });
+                    return Some(result.map_err(|e| (e, self.input.slice_from(start.position()))))
                 }
             }
         }
@@ -337,9 +329,9 @@ where P: QualifiedRuleParser<'i, QualifiedRule = R, Error = E> +
 impl<'i: 't, 't: 'a, 'a, R, P, E: 'i> Iterator for RuleListParser<'i, 't, 'a, P>
 where P: QualifiedRuleParser<'i, QualifiedRule = R, Error = E> +
          AtRuleParser<'i, AtRule = R, Error = E> {
-    type Item = Result<R, PreciseParseError<'i, E>>;
+    type Item = Result<R, (ParseError<'i, E>, &'i str)>;
 
-    fn next(&mut self) -> Option<Result<R, PreciseParseError<'i, E>>> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             if self.is_stylesheet {
                 self.input.skip_cdc_and_cdo()
@@ -375,12 +367,8 @@ where P: QualifiedRuleParser<'i, QualifiedRule = R, Error = E> +
                 }
             } else {
                 self.any_rule_so_far = true;
-                return Some(parse_qualified_rule(self.input, &mut self.parser)
-                            .map_err(|e| PreciseParseError {
-                                error: e,
-                                slice: self.input.slice_from(start.position()),
-                                location: start.source_location(),
-                            }))
+                let result = parse_qualified_rule(self.input, &mut self.parser);
+                return Some(result.map_err(|e| (e, self.input.slice_from(start.position()))))
             }
         }
     }
@@ -390,19 +378,15 @@ where P: QualifiedRuleParser<'i, QualifiedRule = R, Error = E> +
 /// Parse a single declaration, such as an `( /* ... */ )` parenthesis in an `@supports` prelude.
 pub fn parse_one_declaration<'i, 't, P, E>(input: &mut Parser<'i, 't>, parser: &mut P)
                                            -> Result<<P as DeclarationParser<'i>>::Declaration,
-                                                     PreciseParseError<'i, E>>
+                                                     (ParseError<'i, E>, &'i str)>
                                            where P: DeclarationParser<'i, Error = E> {
     let start_position = input.position();
-    let start_location = input.current_source_location();
     input.parse_entirely(|input| {
         let name = input.expect_ident()?.clone();
         input.expect_colon()?;
         parser.parse_value(name, input)
-    }).map_err(|e| PreciseParseError {
-        error: e,
-        slice: input.slice_from(start_position),
-        location: start_location,
     })
+    .map_err(|e| (e, input.slice_from(start_position)))
 }
 
 
@@ -430,28 +414,17 @@ where P: QualifiedRuleParser<'i, QualifiedRule = R, Error = E> +
         }
 
         if let Some(name) = at_keyword {
-            parse_at_rule(&start, name, input, parser).map_err(|e| e.error)
+            parse_at_rule(&start, name, input, parser).map_err(|e| e.0)
         } else {
             parse_qualified_rule(input, parser)
         }
     })
 }
 
-/// A parse error with details of where it occured
-pub struct PreciseParseError<'i, E: 'i> {
-    /// Error details
-    pub error: ParseError<'i, E>,
-
-    /// The relevant slice of the input.
-    pub slice: &'i str,
-
-    /// The line number and column number of the start of the relevant input slice.
-    pub location: SourceLocation,
-}
-
 fn parse_at_rule<'i: 't, 't, P, E>(start: &ParserState, name: CowRcStr<'i>,
                                    input: &mut Parser<'i, 't>, parser: &mut P)
-                                   -> Result<<P as AtRuleParser<'i>>::AtRule, PreciseParseError<'i, E>>
+                                   -> Result<<P as AtRuleParser<'i>>::AtRule,
+                                             (ParseError<'i, E>, &'i str)>
                                    where P: AtRuleParser<'i, Error = E> {
     let delimiters = Delimiter::Semicolon | Delimiter::CurlyBracketBlock;
     // FIXME: https://github.com/rust-lang/rust/issues/42508
@@ -462,11 +435,10 @@ fn parse_at_rule<'i: 't, 't, P, E>(start: &ParserState, name: CowRcStr<'i>,
         Ok(AtRuleType::WithoutBlock(prelude)) => {
             match input.next() {
                 Ok(&Token::Semicolon) | Err(_) => Ok(parser.rule_without_block(prelude)),
-                Ok(&Token::CurlyBracketBlock) => Err(PreciseParseError {
-                    error: ParseError::Basic(BasicParseError::UnexpectedToken(Token::CurlyBracketBlock)),
-                    slice: input.slice_from(start.position()),
-                    location: start.source_location(),
-                }),
+                Ok(&Token::CurlyBracketBlock) => Err((
+                    input.new_unexpected_token_error(Token::CurlyBracketBlock),
+                    input.slice_from(start.position()),
+                )),
                 Ok(_) => unreachable!()
             }
         }
@@ -475,22 +447,13 @@ fn parse_at_rule<'i: 't, 't, P, E>(start: &ParserState, name: CowRcStr<'i>,
                 Ok(&Token::CurlyBracketBlock) => {
                     // FIXME: https://github.com/rust-lang/rust/issues/42508
                     parse_nested_block::<'i, 't, _, _, _>(input, move |input| parser.parse_block(prelude, input))
-                        .map_err(|e| PreciseParseError {
-                            error: e,
-                            slice: input.slice_from(start.position()),
-                            location: start.source_location(),
-                        })
+                        .map_err(|e| (e, input.slice_from(start.position())))
                 }
-                Ok(&Token::Semicolon) => Err(PreciseParseError {
-                    error: ParseError::Basic(BasicParseError::UnexpectedToken(Token::Semicolon)),
-                    slice: input.slice_from(start.position()),
-                    location: start.source_location(),
-                }),
-                Err(e) => Err(PreciseParseError {
-                    error: ParseError::Basic(e),
-                    slice: input.slice_from(start.position()),
-                    location: start.source_location(),
-                }),
+                Ok(&Token::Semicolon) => Err((
+                    input.new_unexpected_token_error(Token::Semicolon),
+                    input.slice_from(start.position()),
+                )),
+                Err(e) => Err((e.into(), input.slice_from(start.position()))),
                 Ok(_) => unreachable!()
             }
         }
@@ -500,11 +463,7 @@ fn parse_at_rule<'i: 't, 't, P, E>(start: &ParserState, name: CowRcStr<'i>,
                 Ok(&Token::CurlyBracketBlock) | Ok(&Token::Semicolon) | Err(_) => {},
                 _ => unreachable!()
             };
-            Err(PreciseParseError {
-                error: error,
-                slice: input.slice(start.position()..end_position),
-                location: start.source_location(),
-            })
+            Err((error, input.slice(start.position()..end_position)))
         }
     }
 }

--- a/src/size_of_tests.rs
+++ b/src/size_of_tests.rs
@@ -42,6 +42,5 @@ size_of_test!(parser, ::parser::Parser, 16);
 size_of_test!(source_position, ::SourcePosition, 8);
 size_of_test!(parser_state, ::ParserState, 24);
 
-size_of_test!(basic_parse_error, ::BasicParseError, 40);
-size_of_test!(parse_error_lower_bound, ::ParseError<()>, 48);
-size_of_test!(precise_parse_error_lower_bound, ::PreciseParseError<()>, 72);
+size_of_test!(basic_parse_error, ::BasicParseError, 48);
+size_of_test!(parse_error_lower_bound, ::ParseError<()>, 56);

--- a/src/unicode_range.rs
+++ b/src/unicode_range.rs
@@ -44,10 +44,10 @@ impl UnicodeRange {
 
         let range = match parse_concatenated(concatenated_tokens.as_bytes()) {
             Ok(range) => range,
-            Err(()) => return Err(BasicParseError::UnexpectedToken(Token::Ident(concatenated_tokens.into()))),
+            Err(()) => return Err(input.new_basic_unexpected_token_error(Token::Ident(concatenated_tokens.into()))),
         };
         if range.end > char::MAX as u32 || range.start > range.end {
-            Err(BasicParseError::UnexpectedToken(Token::Ident(concatenated_tokens.into())))
+            Err(input.new_basic_unexpected_token_error(Token::Ident(concatenated_tokens.into())))
         } else {
             Ok(range)
         }
@@ -57,10 +57,11 @@ impl UnicodeRange {
 fn parse_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), BasicParseError<'i>> {
     match input.next_including_whitespace()?.clone() {
         Token::Delim('+') => {
-            match *input.next_including_whitespace()? {
+            // FIXME: remove .clone() when lifetimes are non-lexical.
+            match input.next_including_whitespace()?.clone() {
                 Token::Ident(_) => {}
                 Token::Delim('?') => {}
-                ref t => return Err(BasicParseError::UnexpectedToken(t.clone()))
+                t => return Err(input.new_basic_unexpected_token_error(t))
             }
             parse_question_marks(input)
         }
@@ -76,7 +77,7 @@ fn parse_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), BasicParseErro
                 _ => input.reset(&after_number)
             }
         }
-        t => return Err(BasicParseError::UnexpectedToken(t))
+        t => return Err(input.new_basic_unexpected_token_error(t))
     }
     Ok(())
 }


### PR DESCRIPTION
This is part of https://bugzilla.mozilla.org/show_bug.cgi?id=1378861

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/200)
<!-- Reviewable:end -->
