### PR TITLE
Use feature testing over version number parsing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,6 @@ smallvec = "0.4.3"
 [build-dependencies]
 syn = "0.11"
 quote = "0.3"
-rustc_version = "0.2"
-
 [features]
 bench = []
 dummy_match_byte = []

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,6 @@
 
 extern crate quote;
 extern crate syn;
-extern crate rustc_version;
 
 use std::env;
 use std::path::Path;
@@ -34,14 +33,7 @@ mod codegen {
 }
 
 fn main() {
-    let rustc = rustc_version::version_meta().unwrap();
-    let commit_date = match rustc.commit_date {
-        Some(ref s) => &**s,
-        None => "unknown",  // Sorts after a date
-    };
-    if (rustc.semver.major, rustc.semver.minor, rustc.semver.patch, commit_date) >=
-       (1, 23, 0, "2017-11-20")
-    {
+    if std::mem::size_of::<Option<bool>>() == 1 {
         // https://github.com/rust-lang/rust/pull/45225
         println!("cargo:rustc-cfg=rustc_has_pr45225")
     }


### PR DESCRIPTION
This is more robust, I’m unsure which release this rustc change will go into.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/206)
<!-- Reviewable:end -->
