### PR TITLE
color: Add a way to hook into the parsing of the components of the color functions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.23.0"
+version = "0.23.1"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub use rules_and_declarations::{DeclarationParser, DeclarationListParser, parse
 pub use rules_and_declarations::{RuleListParser, parse_one_rule};
 pub use rules_and_declarations::{AtRuleType, QualifiedRuleParser, AtRuleParser};
 pub use from_bytes::{stylesheet_encoding, EncodingSupport};
-pub use color::{RGBA, Color, parse_color_keyword};
+pub use color::{RGBA, Color, parse_color_keyword, AngleOrNumber, NumberOrPercentage, ColorComponentParser};
 pub use nth::parse_nth;
 pub use serializer::{ToCss, CssStringWriter, serialize_identifier, serialize_string, TokenSerializationType};
 pub use parser::{Parser, Delimiter, Delimiters, ParserState, ParserInput};


### PR DESCRIPTION
This way we'll be able to implement calc-in-color without duplicating a ton of
code for calc() handling in Servo.

Minor version bump because the API is not broken, just expanded to support
providing an optional `ColorComponentParser`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/207)
<!-- Reviewable:end -->
