### PR TITLE
Add the extra-traits feature to syn in the cssparser-macros crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
   - cargo test --features dummy_match_byte
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test --features bench; fi
   - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo test --features "bench dummy_match_byte"; fi
+  - cd macros && cargo build --verbose
 
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser-macros"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 description = "Procedural macros for cssparser"
 documentation = "https://docs.rs/cssparser-macros/"
@@ -15,5 +15,5 @@ proc-macro = true
 procedural-masquerade = {path = "../procedural-masquerade", version = "0.1"}
 phf_codegen = "0.7"
 quote = "0.4"
-syn = {version = "0.12", features = ["full"]}
+syn = {version = "0.12", features = ["full", "extra-traits"]}
 proc-macro2 = "0.2"


### PR DESCRIPTION
This feature is needed for that crate to compile but since CI was never
compiling it on its own and that cargo features are additive, this never
got caught.

Fixes #214

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/215)
<!-- Reviewable:end -->
