### PR TITLE
Have UnicodeRange not serialize question marks.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.23.3"
+version = "0.23.4"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/unicode_range.rs
+++ b/src/unicode_range.rs
@@ -6,7 +6,6 @@
 
 use {Parser, ToCss, BasicParseError};
 use std::char;
-use std::cmp;
 use std::fmt;
 use tokenizer::Token;
 
@@ -166,32 +165,9 @@ impl fmt::Debug for UnicodeRange {
 
 impl ToCss for UnicodeRange {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-        dest.write_str("U+")?;
-
-        // How many bits are 0 at the end of start and also 1 at the end of end.
-        let bits = cmp::min(self.start.trailing_zeros(), (!self.end).trailing_zeros());
-
-        let question_marks = bits / 4;
-
-        // How many lower bits can be represented as question marks
-        let bits = question_marks * 4;
-
-        let truncated_start = self.start >> bits;
-        let truncated_end = self.end >> bits;
-        if truncated_start == truncated_end {
-            // Bits not covered by question marks are the same in start and end,
-            // we can use the question mark syntax.
-            if truncated_start != 0 {
-                write!(dest, "{:X}", truncated_start)?;
-            }
-            for _ in 0..question_marks {
-                dest.write_str("?")?;
-            }
-        } else {
-            write!(dest, "{:X}", self.start)?;
-            if self.end != self.start {
-                write!(dest, "-{:X}", self.end)?;
-            }
+        write!(dest, "U+{:X}", self.start)?;
+        if self.end != self.start {
+            write!(dest, "-{:X}", self.end)?;
         }
         Ok(())
     }


### PR DESCRIPTION
No browser does that. This causes test failures in Gecko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/218)
<!-- Reviewable:end -->
