### PR TITLE
Expose serializer::serialize_name.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.23.7"
+version = "0.23.8"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -188,8 +188,11 @@ pub fn serialize_identifier<W>(mut value: &str, dest: &mut W) -> fmt::Result whe
     }
 }
 
-
-fn serialize_name<W>(value: &str, dest: &mut W) -> fmt::Result where W:fmt::Write {
+/// Write a CSS name, like a custom property name.
+///
+/// You should only use this when you know what you're doing, when in doubt,
+/// consider using `serialize_identifier`.
+pub fn serialize_name<W>(value: &str, dest: &mut W) -> fmt::Result where W:fmt::Write {
     let mut chunk_start = 0;
     for (i, b) in value.bytes().enumerate() {
         let escaped = match b {


### PR DESCRIPTION
I want to use it to remove some stupid allocations in Servo, which effectively
do:

  serialize_identifier(format!("--{}", custom_prop_name));

And could do instead:

  write_str("--");
  serialize_name(custom_prop_name);

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/221)
<!-- Reviewable:end -->
