### PR TITLE
procedural-masquerade: Give more stack to procedural-masquerade macros.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.23.9"
+version = "0.23.10"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"


### PR DESCRIPTION
This is a prospective fix for https://github.com/servo/servo/issues/21038.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/224)
<!-- Reviewable:end -->
