### PR TITLE
unicode_range: Make UnicodeRange repr(C).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.24.0"
+version = "0.24.1"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/unicode_range.rs
+++ b/src/unicode_range.rs
@@ -13,6 +13,7 @@ use tokenizer::Token;
 ///
 /// Can not be empty. Can represent a single code point when start == end.
 #[derive(PartialEq, Eq, Clone, Hash)]
+#[repr(C)]
 pub struct UnicodeRange {
     /// Inclusive start of the range. In [0, end].
     pub start: u32,


### PR DESCRIPTION
I want to expose it to Gecko via cbindgen without copies to extinguish
nsCSSValue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/228)
<!-- Reviewable:end -->
