### PR TITLE
Mark derive with `$crate::`

### DIFF
--- a/procedural-masquerade/Cargo.toml
+++ b/procedural-masquerade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "procedural-masquerade"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 description = "macro_rules for making proc_macro_derive pretending to be proc_macro"
 documentation = "https://docs.rs/procedural-masquerade/"

--- a/procedural-masquerade/lib.rs
+++ b/procedural-masquerade/lib.rs
@@ -228,7 +228,7 @@ macro_rules! define_invoke_proc_macro {
         #[macro_export]
         macro_rules! $macro_name {
             ($proc_macro_name: ident ! $paren: tt) => {
-                #[derive($proc_macro_name)]
+                #[derive($crate::$proc_macro_name)]
                 #[allow(unused)]
                 enum ProceduralMasqueradeDummyType {
                     // The magic happens here.


### PR DESCRIPTION
There is a problem currently that for example I create a procedural macro `cstr`, if users use
```rust
use cstr::cstr;
let x = cstr!(...);
```
the compiler would complain
> error: cannot find derive macro `cstr_internal__build_bytes` in this scope

This is because the custom derive macro is not imported. So if users want to use this macro, they would need to either use the traditional `#[macro_use] extern crate cstr;` or `use cstr::*;`. Neither is optimal.

This PR adds `$crate::` to the derive so that users of procedural macro can just import the macro they need.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/239)
<!-- Reviewable:end -->
