### PR TITLE
README.md fix ast link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Parsing CSS involves a series of steps:
 * Component values can then be parsed into generic rules or declarations.
   The header and body of rules as well as the value of declarations
   are still just lists of component values at this point.
-  See [the `ast` module](src/ast.rs) for the data structures.
+  See [the `Token` enum](src/tokenizer.rs) for the data structure.
 
 * The last step of a full CSS parser is
   parsing the remaining component values


### PR DESCRIPTION
The `ast.rs` file does not exist anymore... so I'm assuming that's what's supposed to be linked to now?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/240)
<!-- Reviewable:end -->
