### PR TITLE
color: Make cssparser::RGBA #[repr(C)].

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.25.2"
+version = "0.25.3"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/color.rs
+++ b/src/color.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// A color with red, green, blue, and alpha components, in a byte each.
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[repr(C)]
 pub struct RGBA {
     /// The red component.
     pub red: u8,


### PR DESCRIPTION
This will be useful for my efforts of avoiding intermediate representations in
the style system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/241)
<!-- Reviewable:end -->
