### PR TITLE
Add Parser::try_parse, same as Parser::try

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.25.3"
+version = "0.25.4"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -495,12 +495,19 @@ impl<'i: 't, 't> Parser<'i, 't> {
         self.input.tokenizer.seen_var_or_env_functions()
     }
 
+    /// The old name of `try_parse`, which requires raw identifiers in the Rust 2018 edition.
+    #[inline]
+    pub fn try<F, T, E>(&mut self, thing: F) -> Result<T, E>
+    where F: FnOnce(&mut Parser<'i, 't>) -> Result<T, E> {
+        self.try_parse(thing)
+    }
+
     /// Execute the given closure, passing it the parser.
     /// If the result (returned unchanged) is `Err`,
     /// the internal state of the parser  (including position within the input)
     /// is restored to what it was before the call.
     #[inline]
-    pub fn try<F, T, E>(&mut self, thing: F) -> Result<T, E>
+    pub fn try_parse<F, T, E>(&mut self, thing: F) -> Result<T, E>
     where F: FnOnce(&mut Parser<'i, 't>) -> Result<T, E> {
         let start = self.state();
         let result = thing(self);


### PR DESCRIPTION
Fixes https://github.com/servo/rust-cssparser/issues/243

Note that we are not (so far) emitting deprecation warnings for the old name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/244)
<!-- Reviewable:end -->
