### PR TITLE
Expose byte index in tokenizer's position.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.25.5"
+version = "0.25.6"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -520,6 +520,14 @@ impl<'a> Tokenizer<'a> {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
 pub struct SourcePosition(pub(crate) usize);
 
+impl SourcePosition {
+    /// Returns the current byte index in the original input.
+    #[inline]
+    pub fn byte_index(&self) -> usize {
+        self.0
+    }
+}
+
 /// The line and column number for a given position within the input.
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct SourceLocation {


### PR DESCRIPTION
I need it to finish my implementation of Properties and Values syntax.

It works on bytes rather than CSS tokens, but it calls the consume a name
algorithm, for which I'm using cssparser.

However I need to know how much of the input was actually consumed
after consuming a name to continue the parse.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/249)
<!-- Reviewable:end -->
