### PR TITLE
Use MaybeUninit when available 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.25.7"
+version = "0.25.8"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"
@@ -30,6 +30,7 @@ serde = {version = "1.0", optional = true}
 smallvec = "0.6"
 
 [build-dependencies]
+autocfg = "0.1.4"
 syn = { version = "0.15.12", features = ["extra-traits", "fold", "full"] }
 quote = "0.6"
 proc-macro2 = "0.4"

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,6 @@ extern crate proc_macro2;
 
 #[cfg(feature = "dummy_match_byte")]
 mod codegen {
-    use std::path::Path;
     pub fn main() {}
 }
 

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+extern crate autocfg;
 #[macro_use]
 extern crate quote;
 #[macro_use]
@@ -48,6 +49,8 @@ fn main() {
         // https://github.com/rust-lang/rust/pull/45225
         println!("cargo:rustc-cfg=rustc_has_pr45225")
     }
+
+    autocfg::new().emit_has_path("std::mem::MaybeUninit");
 
     codegen::main();
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -530,9 +530,9 @@ pub fn parse_color_keyword(ident: &str) -> Result<Color, ()> {
 #[inline]
 fn from_hex(c: u8) -> Result<u8, ()> {
     match c {
-        b'0'...b'9' => Ok(c - b'0'),
-        b'a'...b'f' => Ok(c - b'a' + 10),
-        b'A'...b'F' => Ok(c - b'A' + 10),
+        b'0'..=b'9' => Ok(c - b'0'),
+        b'a'..=b'f' => Ok(c - b'a' + 10),
+        b'A'..=b'F' => Ok(c - b'A' + 10),
         _ => Err(()),
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -110,13 +110,26 @@ macro_rules! ascii_case_insensitive_phf_map {
 #[doc(hidden)]
 macro_rules! cssparser_internal__to_lowercase {
     ($input: expr, $BUFFER_SIZE: expr => $output: ident) => {
-        // mem::uninitialized() is ok because `buffer` is only used in `_internal__to_lowercase`,
+        let mut buffer;
+        // Safety: `buffer` is only used in `_internal__to_lowercase`,
         // which initializes with `copy_from_slice` the part of the buffer it uses,
         // before it uses it.
         #[allow(unsafe_code)]
-        let mut buffer: [u8; $BUFFER_SIZE] = unsafe { ::std::mem::uninitialized() };
+        let buffer = unsafe {
+            // FIXME: remove this when we require Rust 1.36
+            #[cfg(not(has_std__mem__MaybeUninit))]
+            {
+                buffer = ::std::mem::uninitialized::<[u8; $BUFFER_SIZE]>();
+                &mut buffer
+            }
+            #[cfg(has_std__mem__MaybeUninit)]
+            {
+                buffer = ::std::mem::MaybeUninit::<[u8; $BUFFER_SIZE]>::uninit();
+                &mut *(buffer.as_mut_ptr())
+            }
+        };
         let input: &str = $input;
-        let $output = $crate::_internal__to_lowercase(&mut buffer, input);
+        let $output = $crate::_internal__to_lowercase(buffer, input);
     };
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -130,7 +130,7 @@ macro_rules! cssparser_internal__to_lowercase {
 #[allow(non_snake_case)]
 pub fn _internal__to_lowercase<'a>(buffer: &'a mut [u8], input: &'a str) -> Option<&'a str> {
     if let Some(buffer) = buffer.get_mut(..input.len()) {
-        if let Some(first_uppercase) = input.bytes().position(|byte| matches!(byte, b'A'...b'Z')) {
+        if let Some(first_uppercase) = input.bytes().position(|byte| matches!(byte, b'A'..=b'Z')) {
             buffer.copy_from_slice(input.as_bytes());
             buffer[first_uppercase..].make_ascii_lowercase();
             // `buffer` was initialized to a copy of `input` (which is &str so well-formed UTF-8)

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -105,7 +105,7 @@ fn parse_n_dash_digits(string: &str) -> Result<i32, ()> {
     let bytes = string.as_bytes();
     if bytes.len() >= 3
         && bytes[..2].eq_ignore_ascii_case(b"n-")
-        && bytes[2..].iter().all(|&c| matches!(c, b'0'...b'9'))
+        && bytes[2..].iter().all(|&c| matches!(c, b'0'..=b'9'))
     {
         Ok(parse_number_saturate(&string[1..]).unwrap()) // Include the minus sign
     } else {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -207,7 +207,7 @@ where
             dest.write_str("-")?;
             value = &value[1..];
         }
-        if let digit @ b'0'...b'9' = value.as_bytes()[0] {
+        if let digit @ b'0'..=b'9' = value.as_bytes()[0] {
             hex_escape(digit, dest)?;
             value = &value[1..];
         }
@@ -226,7 +226,7 @@ where
     let mut chunk_start = 0;
     for (i, b) in value.bytes().enumerate() {
         let escaped = match b {
-            b'0'...b'9' | b'A'...b'Z' | b'a'...b'z' | b'_' | b'-' => continue,
+            b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z' | b'_' | b'-' => continue,
             _ if !b.is_ascii() => continue,
             b'\0' => Some("\u{FFFD}"),
             _ => None,
@@ -251,7 +251,7 @@ where
     let mut chunk_start = 0;
     for (i, b) in value.bytes().enumerate() {
         let hex = match b {
-            b'\0'...b' ' | b'\x7F' => true,
+            b'\0'..=b' ' | b'\x7F' => true,
             b'(' | b')' | b'"' | b'\'' | b'\\' => false,
             _ => continue,
         };
@@ -318,7 +318,7 @@ where
                 b'"' => Some("\\\""),
                 b'\\' => Some("\\\\"),
                 b'\0' => Some("\u{FFFD}"),
-                b'\x01'...b'\x1F' | b'\x7F' => None,
+                b'\x01'..=b'\x1F' | b'\x7F' => None,
                 _ => continue,
             };
             self.inner.write_str(&s[chunk_start..i])?;


### PR DESCRIPTION
Fix deprecation warnings for `mem::uninitialized`. (They also affected other crates, since it’s used in a public macro.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-cssparser/252)
<!-- Reviewable:end -->
