### PR TITLE
Unconditionally use MaybeUninit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.31.0
+  - 1.36.0
 
 script:
   - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.25.9"
+version = "0.26.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"
@@ -30,7 +30,6 @@ serde = {version = "1.0", optional = true}
 smallvec = "0.6"
 
 [build-dependencies]
-autocfg = "0.1.4"
 syn = { version = "1", features = ["extra-traits", "fold", "full"] }
 quote = "1"
 proc-macro2 = "1"

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate autocfg;
 #[macro_use]
 extern crate quote;
 #[macro_use]
@@ -49,8 +48,6 @@ fn main() {
         // https://github.com/rust-lang/rust/pull/45225
         println!("cargo:rustc-cfg=rustc_has_pr45225")
     }
-
-    autocfg::new().emit_has_path("std::mem::MaybeUninit");
 
     codegen::main();
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::mem::MaybeUninit;
+
 // See docs of the `procedural-masquerade` crate.
 define_invoke_proc_macro!(cssparser_internal__invoke_proc_macro);
 
@@ -110,40 +112,13 @@ macro_rules! ascii_case_insensitive_phf_map {
 #[doc(hidden)]
 macro_rules! cssparser_internal__to_lowercase {
     ($input: expr, $BUFFER_SIZE: expr => $output: ident) => {
-        let mut buffer;
-        // Safety: `buffer` is only used in `_internal__to_lowercase`,
-        // which initializes with `copy_from_slice` the part of the buffer it uses,
-        // before it uses it.
         #[allow(unsafe_code)]
-        let buffer = unsafe { cssparser_internal__uninit!(buffer, $BUFFER_SIZE) };
+        let mut buffer = unsafe {
+            ::std::mem::MaybeUninit::<[::std::mem::MaybeUninit<u8>; $BUFFER_SIZE]>::uninit().assume_init()
+        };
         let input: &str = $input;
-        let $output = $crate::_internal__to_lowercase(buffer, input);
+        let $output = $crate::_internal__to_lowercase(&mut buffer, input);
     };
-}
-
-#[cfg(has_std__mem__MaybeUninit)]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! cssparser_internal__uninit {
-    ($buffer: ident, $BUFFER_SIZE: expr) => {
-        {
-            $buffer = ::std::mem::MaybeUninit::<[u8; $BUFFER_SIZE]>::uninit();
-            &mut *($buffer.as_mut_ptr())
-        }
-    }
-}
-
-// FIXME: remove this when we require Rust 1.36
-#[cfg(not(has_std__mem__MaybeUninit))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! cssparser_internal__uninit {
-    ($buffer: ident, $BUFFER_SIZE: expr) => {
-        {
-            $buffer = ::std::mem::uninitialized::<[u8; $BUFFER_SIZE]>();
-            &mut $buffer
-        }
-    }
 }
 
 /// Implementation detail of match_ignore_ascii_case! and ascii_case_insensitive_phf_map! macros.
@@ -154,10 +129,14 @@ macro_rules! cssparser_internal__uninit {
 /// Otherwise, return `input` ASCII-lowercased, using `buffer` as temporary space if necessary.
 #[doc(hidden)]
 #[allow(non_snake_case)]
-pub fn _internal__to_lowercase<'a>(buffer: &'a mut [u8], input: &'a str) -> Option<&'a str> {
+pub fn _internal__to_lowercase<'a>(buffer: &'a mut [MaybeUninit<u8>], input: &'a str) -> Option<&'a str> {
     if let Some(buffer) = buffer.get_mut(..input.len()) {
         if let Some(first_uppercase) = input.bytes().position(|byte| matches!(byte, b'A'..=b'Z')) {
-            buffer.copy_from_slice(input.as_bytes());
+            let buffer = unsafe {
+                let ptr = buffer.as_mut_ptr() as *mut u8;
+                std::ptr::copy_nonoverlapping(input.as_bytes().as_ptr(), ptr, input.len());
+                &mut *(buffer as *mut [MaybeUninit<u8>] as *mut [u8])
+            };
             buffer[first_uppercase..].make_ascii_lowercase();
             // `buffer` was initialized to a copy of `input` (which is &str so well-formed UTF-8)
             // then lowercased (which preserves UTF-8 well-formedness)


### PR DESCRIPTION
This raises the minimum Rust version to 1.36.0, so this is a breaking change.