### PR TITLE
Add cargo fmt to travis build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ rust:
   - 1.36.0
 
 script:
+  - |
+    if [[ $TRAVIS_RUST_VERSION == "stable" ]]
+    then
+      rustup component add rustfmt
+      cargo fmt --all -- --check || (echo "Please reformat your code with 'cargo fmt'"; false)
+    fi
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc --verbose


### PR DESCRIPTION
The stable build `cargo fmt` failure(https://travis-ci.com/github/servo/rust-cssparser/jobs/351864972) is fixed in https://github.com/servo/rust-cssparser/pull/271, please merge that PR first.