### PR TITLE
Pass rule start to parser rather than just a location.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.27.2"
+version = "0.28.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/rules_and_declarations.rs
+++ b/src/rules_and_declarations.rs
@@ -5,7 +5,7 @@
 // https://drafts.csswg.org/css-syntax/#parsing
 
 use super::{BasicParseError, BasicParseErrorKind, Delimiter};
-use super::{ParseError, Parser, SourceLocation, Token};
+use super::{ParseError, Parser, Token};
 use crate::cow_rc_str::CowRcStr;
 use crate::parser::{parse_nested_block, parse_until_after, parse_until_before, ParserState};
 
@@ -130,10 +130,10 @@ pub trait AtRuleParser<'i> {
     fn rule_without_block(
         &mut self,
         prelude: Self::PreludeNoBlock,
-        location: SourceLocation,
+        start: &ParserState,
     ) -> Self::AtRule {
         let _ = prelude;
-        let _ = location;
+        let _ = start;
         panic!(
             "The `AtRuleParser::rule_without_block` method must be overriden \
              if `AtRuleParser::parse_prelude` ever returns `AtRuleType::WithoutBlock`."
@@ -153,11 +153,11 @@ pub trait AtRuleParser<'i> {
     fn parse_block<'t>(
         &mut self,
         prelude: Self::PreludeBlock,
-        location: SourceLocation,
+        start: &ParserState,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::AtRule, ParseError<'i, Self::Error>> {
         let _ = prelude;
-        let _ = location;
+        let _ = start;
         let _ = input;
         Err(input.new_error(BasicParseErrorKind::AtRuleBodyInvalid))
     }
@@ -210,11 +210,11 @@ pub trait QualifiedRuleParser<'i> {
     fn parse_block<'t>(
         &mut self,
         prelude: Self::Prelude,
-        location: SourceLocation,
+        start: &ParserState,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::QualifiedRule, ParseError<'i, Self::Error>> {
         let _ = prelude;
-        let _ = location;
+        let _ = start;
         let _ = input;
         Err(input.new_error(BasicParseErrorKind::QualifiedRuleInvalid))
     }
@@ -463,14 +463,13 @@ fn parse_at_rule<'i, 't, P, E>(
 where
     P: AtRuleParser<'i, Error = E>,
 {
-    let location = input.current_source_location();
     let delimiters = Delimiter::Semicolon | Delimiter::CurlyBracketBlock;
     // FIXME: https://github.com/servo/rust-cssparser/issues/254
     let callback = |input: &mut Parser<'i, '_>| parser.parse_prelude(name, input);
     let result = parse_until_before(input, delimiters, callback);
     match result {
         Ok(AtRuleType::WithoutBlock(prelude)) => match input.next() {
-            Ok(&Token::Semicolon) | Err(_) => Ok(parser.rule_without_block(prelude, location)),
+            Ok(&Token::Semicolon) | Err(_) => Ok(parser.rule_without_block(prelude, start)),
             Ok(&Token::CurlyBracketBlock) => Err((
                 input.new_unexpected_token_error(Token::CurlyBracketBlock),
                 input.slice_from(start.position()),
@@ -482,7 +481,7 @@ where
                 Ok(&Token::CurlyBracketBlock) => {
                     // FIXME: https://github.com/servo/rust-cssparser/issues/254
                     let callback =
-                        |input: &mut Parser<'i, '_>| parser.parse_block(prelude, location, input);
+                        |input: &mut Parser<'i, '_>| parser.parse_block(prelude, start, input);
                     parse_nested_block(input, callback)
                         .map_err(|e| (e, input.slice_from(start.position())))
                 }
@@ -512,7 +511,7 @@ fn parse_qualified_rule<'i, 't, P, E>(
 where
     P: QualifiedRuleParser<'i, Error = E>,
 {
-    let location = input.current_source_location();
+    let start = input.state();
     // FIXME: https://github.com/servo/rust-cssparser/issues/254
     let callback = |input: &mut Parser<'i, '_>| parser.parse_prelude(input);
     let prelude = parse_until_before(input, Delimiter::CurlyBracketBlock, callback);
@@ -521,8 +520,7 @@ where
             // Do this here so that we consume the `{` even if the prelude is `Err`.
             let prelude = prelude?;
             // FIXME: https://github.com/servo/rust-cssparser/issues/254
-            let callback =
-                |input: &mut Parser<'i, '_>| parser.parse_block(prelude, location, input);
+            let callback = |input: &mut Parser<'i, '_>| parser.parse_block(prelude, &start, input);
             parse_nested_block(input, callback)
         }
         _ => unreachable!(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,8 +16,8 @@ use super::{
     parse_important, parse_nth, parse_one_declaration, parse_one_rule, stylesheet_encoding,
     AtRuleParser, AtRuleType, BasicParseError, BasicParseErrorKind, Color, CowRcStr,
     DeclarationListParser, DeclarationParser, Delimiter, EncodingSupport, ParseError,
-    ParseErrorKind, Parser, ParserInput, QualifiedRuleParser, RuleListParser, SourceLocation,
-    ToCss, Token, TokenSerializationType, UnicodeRange, RGBA,
+    ParseErrorKind, Parser, ParserInput, ParserState, QualifiedRuleParser, RuleListParser,
+    SourceLocation, ToCss, Token, TokenSerializationType, UnicodeRange, RGBA,
 };
 
 macro_rules! JArray {
@@ -946,7 +946,7 @@ impl<'i> AtRuleParser<'i> for JsonParser {
         }
     }
 
-    fn rule_without_block(&mut self, mut prelude: Vec<Value>, _location: SourceLocation) -> Value {
+    fn rule_without_block(&mut self, mut prelude: Vec<Value>, _: &ParserState) -> Value {
         prelude.push(Value::Null);
         Value::Array(prelude)
     }
@@ -954,7 +954,7 @@ impl<'i> AtRuleParser<'i> for JsonParser {
     fn parse_block<'t>(
         &mut self,
         mut prelude: Vec<Value>,
-        _location: SourceLocation,
+        _: &ParserState,
         input: &mut Parser<'i, 't>,
     ) -> Result<Value, ParseError<'i, ()>> {
         prelude.push(Value::Array(component_values_to_json(input)));
@@ -977,7 +977,7 @@ impl<'i> QualifiedRuleParser<'i> for JsonParser {
     fn parse_block<'t>(
         &mut self,
         prelude: Vec<Value>,
-        _location: SourceLocation,
+        _: &ParserState,
         input: &mut Parser<'i, 't>,
     ) -> Result<Value, ParseError<'i, ()>> {
         Ok(JArray![


### PR DESCRIPTION
This is:

 * More generic, as the state has more information like the source
   index.

 * Slightly cheaper to compute, as the source location requires math to
   compute, which the parser state doesn't

I need this to improve CSS sanitization in Gecko.

https://bugzilla.mozilla.org/show_bug.cgi?id=1680084