### PR TITLE
macros: Optimize cssparser_internal_to_lowercase for already-lowercase inputs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.28.0"
+version = "0.28.1"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"


### PR DESCRIPTION
By inlining the happy-path. this improves CSS parsing performance of
benchmarks, even on PGO builds.