### PR TITLE
Tweak at-rule parsing API to allow a single at-rule to be block or blockless.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.28.1"
+version = "0.29.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub use crate::parser::{BasicParseError, BasicParseErrorKind, ParseError, ParseE
 pub use crate::parser::{Delimiter, Delimiters, Parser, ParserInput, ParserState};
 pub use crate::rules_and_declarations::{parse_important, parse_one_declaration};
 pub use crate::rules_and_declarations::{parse_one_rule, RuleListParser};
-pub use crate::rules_and_declarations::{AtRuleParser, AtRuleType, QualifiedRuleParser};
+pub use crate::rules_and_declarations::{AtRuleParser, QualifiedRuleParser};
 pub use crate::rules_and_declarations::{DeclarationListParser, DeclarationParser};
 pub use crate::serializer::{serialize_identifier, serialize_name, serialize_string};
 pub use crate::serializer::{CssStringWriter, ToCss, TokenSerializationType};


### PR DESCRIPTION
This is needed for @layer, which can be block or blockless.