### PR TITLE
Replace deprecated std constants by associated constants.

### DIFF
--- a/src/cow_rc_str.rs
+++ b/src/cow_rc_str.rs
@@ -12,7 +12,6 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::slice;
 use std::str;
-use std::usize;
 
 /// A string that is either shared (heap-allocated and reference-counted) or borrowed.
 ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -631,7 +631,6 @@ fn line_numbers() {
 
 #[test]
 fn overflow() {
-    use std::f32;
     use std::iter::repeat;
 
     let css = r"

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -9,7 +9,6 @@ use crate::cow_rc_str::CowRcStr;
 use crate::parser::ParserState;
 use matches::matches;
 use std::char;
-use std::i32;
 use std::ops::Range;
 
 /// One of the pieces the CSS input is broken into.


### PR DESCRIPTION
This PR aims to fix a few minor deprecation warnings.
See https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html#library-changes and https://doc.rust-lang.org/stable/std/usize/index.html for details.