### PR TITLE
Make `ParseError` a `std::error::Error`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,6 +5,7 @@
 use crate::cow_rc_str::CowRcStr;
 use crate::tokenizer::{SourceLocation, SourcePosition, Token, Tokenizer};
 use smallvec::SmallVec;
+use std::fmt;
 use std::ops::BitOr;
 use std::ops::Range;
 
@@ -51,6 +52,24 @@ pub enum BasicParseErrorKind<'i> {
     AtRuleBodyInvalid,
     /// A qualified rule was encountered that was invalid.
     QualifiedRuleInvalid,
+}
+
+impl<'i> fmt::Display for BasicParseErrorKind<'i> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BasicParseErrorKind::UnexpectedToken(token) => {
+                write!(f, "unexpected token: {:?}", token)
+            }
+            BasicParseErrorKind::EndOfInput => write!(f, "unexpected end of input"),
+            BasicParseErrorKind::AtRuleInvalid(rule) => {
+                write!(f, "invalid @ rule encountered: '@{rule}'")
+            }
+            BasicParseErrorKind::AtRuleBodyInvalid => write!(f, "invalid @ rule body encountered"),
+            BasicParseErrorKind::QualifiedRuleInvalid => {
+                write!(f, "invalid qualified rule encountered")
+            }
+        }
+    }
 }
 
 /// The fundamental parsing errors that can be triggered by built-in parsing routines.
@@ -123,6 +142,15 @@ impl<'i, T> ParseErrorKind<'i, T> {
     }
 }
 
+impl<'i, E: fmt::Display> fmt::Display for ParseErrorKind<'i, E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ParseErrorKind::Basic(ref basic) => basic.fmt(f),
+            ParseErrorKind::Custom(ref custom) => custom.fmt(f),
+        }
+    }
+}
+
 /// Extensible parse errors that can be encountered by client parsing implementations.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ParseError<'i, E> {
@@ -137,7 +165,7 @@ impl<'i, T> ParseError<'i, T> {
     pub fn basic(self) -> BasicParseError<'i> {
         match self.kind {
             ParseErrorKind::Basic(kind) => BasicParseError {
-                kind: kind,
+                kind,
                 location: self.location,
             },
             ParseErrorKind::Custom(_) => panic!("Not a basic parse error"),
@@ -155,6 +183,14 @@ impl<'i, T> ParseError<'i, T> {
         }
     }
 }
+
+impl<'i, E: fmt::Display> fmt::Display for ParseError<'i, E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.kind.fmt(f)
+    }
+}
+
+impl<'i, E: fmt::Display + fmt::Debug> std::error::Error for ParseError<'i, E> {}
 
 /// The owned input for a parser.
 pub struct ParserInput<'i> {
@@ -396,7 +432,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
     #[inline]
     pub fn new_basic_error(&self, kind: BasicParseErrorKind<'i>) -> BasicParseError<'i> {
         BasicParseError {
-            kind: kind,
+            kind,
             location: self.current_source_location(),
         }
     }


### PR DESCRIPTION
Previously the `ParseError` struct did not implement
`std::error::Error` or `std::fmt::Display`. This meant that `ParseError`
was not boxable into an "any error" box like `anyhow::Error`. This
commit adds Error and Display implementations for ParseError and
friends.
