### PR TITLE
Update phf to 0.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.36.0
+          - 1.40.0
         features:
           -
           - --features dummy_match_byte

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cssparser-macros = {path = "./macros", version = "0.6"}
 dtoa-short = "0.3"
 itoa = "0.4"
 matches = "0.1"
-phf = {version = "0.8", features = ["macros"]}
+phf = {version = "0.10", features = ["macros"]}
 serde = {version = "1.0", optional = true}
 smallvec = "1.0"
 


### PR DESCRIPTION
phf 0.8 still uses rand_core version <0.6.2 which suffer from [CVE-2021-27378](https://nvd.nist.gov/vuln/detail/CVE-2021-27378).
Every crate depends on it will be warned by cargo audit.