### PR TITLE
Bump version to 0.30.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.30.0"
+version = "0.29.3"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.29.2"
+version = "0.30.0"
 authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
 
 description = "Rust implementation of CSS Syntax Level 3"


### PR DESCRIPTION
Sorry I forgot to add the version bump in previous PR.
~~I bump the patch version since this doesn't add or change anything in cssparser itself?~~
Just realized this changed the minimum rust version.