### PR TITLE
Shrink unsafe block

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -157,22 +157,22 @@ pub fn _cssparser_internal_to_lowercase<'a>(
         input: &'a str,
         first_uppercase: usize,
     ) -> &'a str {
-        unsafe {
+        
             // This cast doesn't change the pointer's validity
             // since `u8` has the same layout as `MaybeUninit<u8>`:
-            let input_bytes = &*(input.as_bytes() as *const [u8] as *const [MaybeUninit<u8>]);
+            let input_bytes = unsafe { &*(input.as_bytes() as *const [u8] as *const [MaybeUninit<u8>]) };
 
             buffer.copy_from_slice(&*input_bytes);
 
             // Same as above re layout, plus these bytes have been initialized:
-            let buffer = &mut *(buffer as *mut [MaybeUninit<u8>] as *mut [u8]);
+            let buffer = unsafe { &mut *(buffer as *mut [MaybeUninit<u8>] as *mut [u8]) };
 
             buffer[first_uppercase..].make_ascii_lowercase();
             // `buffer` was initialized to a copy of `input`
             // (which is `&str` so well-formed UTF-8)
             // then ASCII-lowercased (which preserves UTF-8 well-formedness):
-            ::std::str::from_utf8_unchecked(buffer)
-        }
+            unsafe { ::std::str::from_utf8_unchecked(buffer) }
+        
     }
 
     Some(


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html