### PR TITLE
feat(color): Refactor existing color parsing to better align with spec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,8 @@ fn parse_border_spacing(_context: &ParserContext, input: &mut Parser)
 #![recursion_limit = "200"] // For color::parse_color_keyword
 
 pub use crate::color::{
-    hsl_to_rgb, hwb_to_rgb, parse_color_keyword, AngleOrNumber, Color, ColorComponentParser,
-    NumberOrPercentage, RGBA,
+    hsl_to_rgb, hwb_to_rgb, parse_color_keyword, AlphaValue, AngleOrNumber, Color,
+    ColorComponentParser, Hue, NumberOrPercentage, RGBA,
 };
 pub use crate::cow_rc_str::CowRcStr;
 pub use crate::from_bytes::{stylesheet_encoding, EncodingSupport};


### PR DESCRIPTION
Add public structs `Hue` and `AlphaValue`.

Add methods `parse_hue()` and `parse_alpha_value()` to public trait `ColorComponentParser`.

Add or update documentation to include links to relevant sections of css-color-4 draft.

----

Following on from my comment on #293, I've gone ahead and refactored the color parsing code to better align with the text of the draft css-color-4 spec, which also allows for easier extension to support the multitude of new functionality that is being specified. (I already have a working implementation of the `none` keyword nearing completion based on these changes, for example.)

I don't know the policy on removing public features, so I've left in the `NumberOrPercentage` and `AngleOrNumber` enums and the `parse_angle_or_number()` and `parse_number_or_percentage()` methods of `ColorComponentParser`, even though I think they are now redundant. I'd be happy to remove them in a later PR, if that's deemed appropriate.

For reference, the latest draft of css-color-4 is available here:
https://w3c.github.io/csswg-drafts/css-color-4/