### PR TITLE
Bump MSRV to 1.56

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.40.0
+          - 1.56.0
         features:
           -
           - --features dummy_match_byte
@@ -34,10 +34,6 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           override: true
-
-      - name: Downgrade phf to a version compatible with the MSRV
-        run: cargo update --package phf --precise 0.10.1
-        if: matrix.toolchain == '1.40.0'
 
       - name: Cargo build
         run: cargo build ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["css", "syntax", "parser"]
 license = "MPL-2.0"
 build = "build.rs"
 edition = "2018"
+rust-version = "1.56"
 
 exclude = ["src/css-parsing-tests/**", "src/big-data-url.css"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cssparser-macros = {path = "./macros", version = "0.6"}
 dtoa-short = "0.3"
 itoa = "1.0"
 matches = "0.1"
-phf = {version = ">=0.8,<=0.11", features = ["macros"]}
+phf = {version = "~0.9", features = ["macros"]}
 serde = {version = "1.0", optional = true}
 smallvec = "1.0"
 


### PR DESCRIPTION
[RUSTSEC-2021-0023](https://rustsec.org/advisories/RUSTSEC-2021-0023.html) reported a vulnerability in rand_core < 0.6.2. rand_core is a part of rand. The fix in rand_core 0.6.2 was first included in rand 0.8.4.

phf_generator is a part of phf. phf_generator depends on rand. The first release of phf (including phf_generator) to depend on rand 0.8, and thus be likely to be using rand >= 0.8.4, was phf 0.9.0.

#300 (1e4fe23fc5878bf164cb2b0ad6351207ff10ed28) updated rust-cssparser to depend on phf 0.10, possibly because the latest phf 0.9 version (0.9.1) was yanked and replaced.

Prior this change, for reasons unclear, rust-cssparser had an apparent MSRV of 1.36. #300 (8ef116b2d0cd16ed29fc0e11096386d6b153c50c) bumped that up to 1.40 because phf_shared 0.9.0 makes use of `#[non_exhaustive]`.

However, phf 0.9 (and thus 0.10) reports in its changelog that it has an MSRV of 1.41 or 1.46, supposedly due to its dependencies. Thus, it is possible that rust 1.40 could not compile rust-cssparser in certain situations (though this seemingly did not manifest in CI).

In an apparent attempt to fix this, 7cb520633e4f0da48315bda20d8955d9652bb270 was committed directly to master without a reviewed PR. This change reverted the phf dependency in a way that allowed the vulnerable phf 0.8 to be used again while also restricting the use of phf >= 0.11 (`">=0.8,<=0.10"`).

#306 (9f936c08dcd96e8c3fda914f5d3f5ec24aecd4db) identified this issue, but resolved it simply by bumping the restriction to phf >= 0.12 (`">=0.8,<=0.11"`).

A more flexible version specification, which I use here, is `"~0.9"`, though this again raises the possibility that rust-cssparser does not compile on rust 1.40.

----

Separately, both @tiaanl and I have been attempting in our recent work to make use of `f32::clamp`, which was not stabilized until rust 1.50.

Additionally, it would be good to explicitly specify the MSRV in Cargo.toml, rather than just in the CI configuration. But that was not supported officially until rust 1.56, which also just so happened to be the first version to support the 2021 edition.

As such, I am proposing that we bump the rust-cssparser MSRV to 1.56.

In checking some packages that depend on rust-cssparser, and comparing the versions of rust available on various platforms, I have not been able to anticipate any downsides to this. I am currently operating under the assumption that it is merely the passage of time that has made the current MSRV so old.

cc @tiaanl @emilio @wusyong @adamreichold 