### PR TITLE
Use the `std::matches!` macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ encoding_rs = "0.8"
 cssparser-macros = {path = "./macros", version = "0.6"}
 dtoa-short = "0.3"
 itoa = "1.0"
-matches = "0.1"
 phf = {version = ">=0.8,<=0.11", features = ["macros"]}
 serde = {version = "1.0", optional = true}
 smallvec = "1.0"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use matches::matches;
 use std::mem::MaybeUninit;
 
 /// Expands to a `match` expression with string patterns,

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::{BasicParseError, Parser, ParserInput, Token};
-use matches::matches;
 
 /// Parse the *An+B* notation, as found in the `:nth-child()` selector.
 /// The input is typically the arguments of a function,

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -4,7 +4,6 @@
 
 use dtoa_short::{self, Notation};
 use itoa;
-use matches::matches;
 use std::fmt::{self, Write};
 use std::str;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,7 +6,6 @@
 extern crate test;
 
 use encoding_rs;
-use matches::matches;
 use serde_json::{self, json, Map, Value};
 
 #[cfg(feature = "bench")]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -7,7 +7,6 @@
 use self::Token::*;
 use crate::cow_rc_str::CowRcStr;
 use crate::parser::ParserState;
-use matches::matches;
 use std::char;
 use std::i32;
 use std::ops::Range;


### PR DESCRIPTION
The `matches` crate can be removed since MSRV is 1.56.