### PR TITLE
Add none keyword

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1269,6 +1269,21 @@ where
     })
 }
 
+fn parse_modern_alpha<'i, 't, P>(
+    color_parser: &P,
+    arguments: &mut Parser<'i, 't>,
+) -> Result<Option<f32>, ParseError<'i, P::Error>>
+where
+    P: ColorParser<'i>,
+{
+    if !arguments.is_exhausted() {
+        arguments.expect_delim('/')?;
+        parse_none_or(arguments, |p| parse_alpha_component(color_parser, p))
+    } else {
+        Ok(Some(OPAQUE))
+    }
+}
+
 #[inline]
 fn parse_rgb<'i, 't, P>(
     color_parser: &P,
@@ -1324,12 +1339,7 @@ where
             color_parser.parse_number_or_percentage(p)
         })?);
 
-        if !arguments.is_exhausted() {
-            arguments.expect_delim('/')?;
-            parse_none_or(arguments, |p| parse_alpha_component(color_parser, p))?.unwrap_or(0.0)
-        } else {
-            OPAQUE
-        }
+        parse_modern_alpha(color_parser, arguments)?.unwrap_or(0.0)
     };
 
     Ok(P::Output::from_rgba(red, green, blue, alpha))
@@ -1364,12 +1374,7 @@ where
         saturation = parse_none_or(arguments, |p| color_parser.parse_percentage(p))?.unwrap_or(0.0);
         lightness = parse_none_or(arguments, |p| color_parser.parse_percentage(p))?.unwrap_or(0.0);
 
-        if !arguments.is_exhausted() {
-            arguments.expect_delim('/')?;
-            parse_none_or(arguments, |p| parse_alpha_component(color_parser, p))?.unwrap_or(0.0)
-        } else {
-            OPAQUE
-        }
+        parse_modern_alpha(color_parser, arguments)?.unwrap_or(0.0)
     };
 
     let hue = if let Some(h) = maybe_hue {
@@ -1570,12 +1575,7 @@ where
     let r2 = parse_none_or(input, |p| f2(color_parser, p))?;
     let r3 = parse_none_or(input, |p| f3(color_parser, p))?;
 
-    let alpha = if !input.is_exhausted() {
-        input.expect_delim('/')?;
-        parse_none_or(input, |p| parse_alpha_component(color_parser, p))?
-    } else {
-        Some(OPAQUE)
-    };
+    let alpha = parse_modern_alpha(color_parser, input)?;
 
     Ok((r1, r2, r3, alpha))
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -13,18 +13,13 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 const OPAQUE: f32 = 1.0;
 
-// This impl should only live in this module and should not be `pub`. We don't
-// want any other Option<T> to serialize to "none".
-impl<'a, T: ToCss> ToCss for Option<T> {
-    fn to_css<W>(&self, dest: &mut W) -> fmt::Result
-    where
-        W: fmt::Write,
-    {
-        if let Some(v) = self {
-            ToCss::to_css(v, dest)
-        } else {
-            dest.write_str("none")
-        }
+fn serialize_none_or<T>(dest: &mut impl fmt::Write, value: &Option<T>) -> fmt::Result
+where
+    T: ToCss,
+{
+    match value {
+        Some(v) => v.to_css(dest),
+        None => dest.write_str("none"),
     }
 }
 
@@ -415,11 +410,11 @@ macro_rules! impl_lab_like {
             {
                 dest.write_str($fname)?;
                 dest.write_str("(")?;
-                self.lightness.to_css(dest)?;
+                serialize_none_or(dest, &self.lightness)?;
                 dest.write_char(' ')?;
-                self.a.to_css(dest)?;
+                serialize_none_or(dest, &self.a)?;
                 dest.write_char(' ')?;
-                self.b.to_css(dest)?;
+                serialize_none_or(dest, &self.b)?;
                 serialize_alpha(dest, self.alpha, false)?;
                 dest.write_char(')')
             }
@@ -508,11 +503,11 @@ macro_rules! impl_lch_like {
             {
                 dest.write_str($fname)?;
                 dest.write_str("(")?;
-                self.lightness.to_css(dest)?;
+                serialize_none_or(dest, &self.lightness)?;
                 dest.write_char(' ')?;
-                self.chroma.to_css(dest)?;
+                serialize_none_or(dest, &self.chroma)?;
                 dest.write_char(' ')?;
-                self.hue.to_css(dest)?;
+                serialize_none_or(dest, &self.hue)?;
                 serialize_alpha(dest, self.alpha, false)?;
                 dest.write_char(')')
             }
@@ -633,11 +628,11 @@ impl ToCss for ColorFunction {
         dest.write_str("color(")?;
         self.color_space.to_css(dest)?;
         dest.write_char(' ')?;
-        self.c1.to_css(dest)?;
+        serialize_none_or(dest, &self.c1)?;
         dest.write_char(' ')?;
-        self.c2.to_css(dest)?;
+        serialize_none_or(dest, &self.c2)?;
         dest.write_char(' ')?;
-        self.c3.to_css(dest)?;
+        serialize_none_or(dest, &self.c3)?;
 
         serialize_alpha(dest, self.alpha, false)?;
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -84,9 +84,9 @@ impl RGBA {
         alpha: Option<f32>,
     ) -> Self {
         Self::new(
-            red.map(|r| clamp_unit_f32(r)),
-            green.map(|g| clamp_unit_f32(g)),
-            blue.map(|b| clamp_unit_f32(b)),
+            red.map(clamp_unit_f32),
+            green.map(clamp_unit_f32),
+            blue.map(clamp_unit_f32),
             alpha.map(|a| a.clamp(0.0, OPAQUE)),
         )
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -842,31 +842,30 @@ pub trait FromParsedColor {
 
 /// Parse a color hash, without the leading '#' character.
 #[inline]
-
-pub fn parse_hash_color<'i, 't, P>(value: &[u8]) -> Result<P::Output, ()>
+pub fn parse_hash_color<'i, 't, O>(value: &[u8]) -> Result<O, ()>
 where
-    P: ColorParser<'i>,
+    O: FromParsedColor,
 {
     Ok(match value.len() {
-        8 => P::Output::from_rgba(
+        8 => O::from_rgba(
             Some(from_hex(value[0])? * 16 + from_hex(value[1])?),
             Some(from_hex(value[2])? * 16 + from_hex(value[3])?),
             Some(from_hex(value[4])? * 16 + from_hex(value[5])?),
             Some((from_hex(value[6])? * 16 + from_hex(value[7])?) as f32 / 255.0),
         ),
-        6 => P::Output::from_rgba(
+        6 => O::from_rgba(
             Some(from_hex(value[0])? * 16 + from_hex(value[1])?),
             Some(from_hex(value[2])? * 16 + from_hex(value[3])?),
             Some(from_hex(value[4])? * 16 + from_hex(value[5])?),
             Some(OPAQUE),
         ),
-        4 => P::Output::from_rgba(
+        4 => O::from_rgba(
             Some(from_hex(value[0])? * 17),
             Some(from_hex(value[1])? * 17),
             Some(from_hex(value[2])? * 17),
             Some((from_hex(value[3])? * 17) as f32 / 255.0),
         ),
-        3 => P::Output::from_rgba(
+        3 => O::from_rgba(
             Some(from_hex(value[0])? * 17),
             Some(from_hex(value[1])? * 17),
             Some(from_hex(value[2])? * 17),
@@ -888,9 +887,7 @@ where
     let location = input.current_source_location();
     let token = input.next()?;
     match *token {
-        Token::Hash(ref value) | Token::IDHash(ref value) => {
-            parse_hash_color::<P>(value.as_bytes())
-        }
+        Token::Hash(ref value) | Token::IDHash(ref value) => parse_hash_color(value.as_bytes()),
         Token::Ident(ref value) => parse_color_keyword(&*value),
         Token::Function(ref name) => {
             let name = name.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,8 @@ fn parse_border_spacing(_context: &ParserContext, input: &mut Parser)
 #![recursion_limit = "200"] // For color::parse_color_keyword
 
 pub use crate::color::{
-    hsl_to_rgb, hwb_to_rgb, parse_color_keyword, parse_color_with, AngleOrNumber, Color,
-    ColorFunction, ColorParser, FromParsedColor, Lab, Lch, NumberOrPercentage, Oklab, Oklch,
+    hsl_to_rgb, hwb_to_rgb, parse_color_keyword, parse_color_with, parse_hash_color, AngleOrNumber,
+    Color, ColorFunction, ColorParser, FromParsedColor, Lab, Lch, NumberOrPercentage, Oklab, Oklch,
     PredefinedColorSpace, RGBA,
 };
 pub use crate::cow_rc_str::CowRcStr;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1626,20 +1626,20 @@ fn generic_parser() {
         ("rgba(1, 2, 3, 0.4)",          OutputType::Rgba(Some(1), Some(2), Some(3), Some(0.4))),
         ("rgb(none none none / none)",  OutputType::Rgba(None, None, None, None)),
         ("rgb(1 none 3 / none)",        OutputType::Rgba(Some(1), None, Some(3), None)),
-        
+
         ("hsla(45deg, 20%, 30%, 0.4)",  OutputType::Hsl(Some(45.0), Some(0.2), Some(0.3), Some(0.4))),
         ("hsl(45deg none none)",        OutputType::Hsl(Some(45.0), None, None, Some(1.0))),
         ("hsl(none 10% none / none)",   OutputType::Hsl(None, Some(0.1), None, None)),
         ("hsl(120 100.0% 50.0%)",       OutputType::Hsl(Some(120.0), Some(1.0), Some(0.5), Some(1.0))),
-        
+
         ("hwb(45deg 20% 30% / 0.4)",    OutputType::Hwb(Some(45.0), Some(0.2), Some(0.3), Some(0.4))),
-        
+
         ("lab(100 20 30 / 0.4)",        OutputType::Lab(Some(100.0), Some(20.0), Some(30.0), Some(0.4))),
         ("lch(100 20 30 / 0.4)",        OutputType::Lch(Some(100.0), Some(20.0), Some(30.0), Some(0.4))),
-        
+
         ("oklab(100 20 30 / 0.4)",      OutputType::Oklab(Some(100.0), Some(20.0), Some(30.0), Some(0.4))),
         ("oklch(100 20 30 / 0.4)",      OutputType::Oklch(Some(100.0), Some(20.0), Some(30.0), Some(0.4))),
-        
+
         ("color(srgb 0.1 0.2 0.3 / 0.4)",           OutputType::ColorFunction(PredefinedColorSpace::Srgb, Some(0.1), Some(0.2), Some(0.3), Some(0.4))),
         ("color(srgb none none none)",              OutputType::ColorFunction(PredefinedColorSpace::Srgb, None, None, None, Some(1.0))),
         ("color(srgb none none none / none)",       OutputType::ColorFunction(PredefinedColorSpace::Srgb, None, None, None, None)),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1519,13 +1519,19 @@ fn generic_parser() {
     enum OutputType {
         CurrentColor,
         Rgba(u8, u8, u8, f32),
-        Hsl(f32, f32, f32, f32),
-        Hwb(f32, f32, f32, f32),
-        Lab(f32, f32, f32, f32),
-        Lch(f32, f32, f32, f32),
-        Oklab(f32, f32, f32, f32),
-        Oklch(f32, f32, f32, f32),
-        ColorFunction(PredefinedColorSpace, f32, f32, f32, f32),
+        Hsl(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
+        Hwb(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
+        Lab(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
+        Lch(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
+        Oklab(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
+        Oklch(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
+        ColorFunction(
+            PredefinedColorSpace,
+            Option<f32>,
+            Option<f32>,
+            Option<f32>,
+            Option<f32>,
+        ),
     }
 
     impl FromParsedColor for OutputType {
@@ -1537,43 +1543,73 @@ fn generic_parser() {
             OutputType::Rgba(red, green, blue, alpha)
         }
 
-        fn from_hsl(hue: f32, saturation: f32, lightness: f32, alpha: f32) -> Self {
+        fn from_hsl(
+            hue: Option<f32>,
+            saturation: Option<f32>,
+            lightness: Option<f32>,
+            alpha: Option<f32>,
+        ) -> Self {
             OutputType::Hsl(hue, saturation, lightness, alpha)
         }
 
-        fn from_hwb(hue: f32, blackness: f32, whiteness: f32, alpha: f32) -> Self {
+        fn from_hwb(
+            hue: Option<f32>,
+            blackness: Option<f32>,
+            whiteness: Option<f32>,
+            alpha: Option<f32>,
+        ) -> Self {
             OutputType::Hwb(hue, blackness, whiteness, alpha)
         }
 
-        fn from_lab(lightness: f32, a: f32, b: f32, alpha: f32) -> Self {
+        fn from_lab(
+            lightness: Option<f32>,
+            a: Option<f32>,
+            b: Option<f32>,
+            alpha: Option<f32>,
+        ) -> Self {
             OutputType::Lab(lightness, a, b, alpha)
         }
 
-        fn from_lch(lightness: f32, chroma: f32, hue: f32, alpha: f32) -> Self {
+        fn from_lch(
+            lightness: Option<f32>,
+            chroma: Option<f32>,
+            hue: Option<f32>,
+            alpha: Option<f32>,
+        ) -> Self {
             OutputType::Lch(lightness, chroma, hue, alpha)
         }
 
-        fn from_oklab(lightness: f32, a: f32, b: f32, alpha: f32) -> Self {
+        fn from_oklab(
+            lightness: Option<f32>,
+            a: Option<f32>,
+            b: Option<f32>,
+            alpha: Option<f32>,
+        ) -> Self {
             OutputType::Oklab(lightness, a, b, alpha)
         }
 
-        fn from_oklch(lightness: f32, chroma: f32, hue: f32, alpha: f32) -> Self {
+        fn from_oklch(
+            lightness: Option<f32>,
+            chroma: Option<f32>,
+            hue: Option<f32>,
+            alpha: Option<f32>,
+        ) -> Self {
             OutputType::Oklch(lightness, chroma, hue, alpha)
         }
 
         fn from_color_function(
             color_space: PredefinedColorSpace,
-            c1: f32,
-            c2: f32,
-            c3: f32,
-            alpha: f32,
+            c1: Option<f32>,
+            c2: Option<f32>,
+            c3: Option<f32>,
+            alpha: Option<f32>,
         ) -> Self {
             OutputType::ColorFunction(color_space, c1, c2, c3, alpha)
         }
     }
 
-    struct ComponentParser;
-    impl<'i> ColorParser<'i> for ComponentParser {
+    struct TestColorParser;
+    impl<'i> ColorParser<'i> for TestColorParser {
         type Output = OutputType;
         type Error = ();
     }
@@ -1584,59 +1620,123 @@ fn generic_parser() {
         ("rgba(1, 2, 3, 0.4)", OutputType::Rgba(1, 2, 3, 0.4)),
         (
             "hsla(45deg, 20%, 30%, 0.4)",
-            OutputType::Hsl(45.0, 0.2, 0.3, 0.4),
+            OutputType::Hsl(Some(45.0), Some(0.2), Some(0.3), Some(0.4)),
+        ),
+        (
+            "hsl(45deg none none)",
+            OutputType::Hsl(Some(45.0), None, None, Some(1.0)),
+        ),
+        (
+            "hsl(none 10% none / none)",
+            OutputType::Hsl(None, Some(0.1), None, None),
         ),
         (
             "hwb(45deg 20% 30% / 0.4)",
-            OutputType::Hwb(45.0, 0.2, 0.3, 0.4),
+            OutputType::Hwb(Some(45.0), Some(0.2), Some(0.3), Some(0.4)),
         ),
         (
             "lab(100 20 30 / 0.4)",
-            OutputType::Lab(100.0, 20.0, 30.0, 0.4),
+            OutputType::Lab(Some(100.0), Some(20.0), Some(30.0), Some(0.4)),
         ),
         (
             "lch(100 20 30 / 0.4)",
-            OutputType::Lch(100.0, 20.0, 30.0, 0.4),
+            OutputType::Lch(Some(100.0), Some(20.0), Some(30.0), Some(0.4)),
         ),
         (
             "oklab(100 20 30 / 0.4)",
-            OutputType::Oklab(100.0, 20.0, 30.0, 0.4),
+            OutputType::Oklab(Some(100.0), Some(20.0), Some(30.0), Some(0.4)),
         ),
         (
             "oklch(100 20 30 / 0.4)",
-            OutputType::Oklch(100.0, 20.0, 30.0, 0.4),
+            OutputType::Oklch(Some(100.0), Some(20.0), Some(30.0), Some(0.4)),
         ),
         (
             "color(srgb 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(PredefinedColorSpace::Srgb, 0.1, 0.2, 0.3, 0.4),
+            OutputType::ColorFunction(
+                PredefinedColorSpace::Srgb,
+                Some(0.1),
+                Some(0.2),
+                Some(0.3),
+                Some(0.4),
+            ),
         ),
         (
             "color(srgb-linear 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(PredefinedColorSpace::SrgbLinear, 0.1, 0.2, 0.3, 0.4),
+            OutputType::ColorFunction(
+                PredefinedColorSpace::SrgbLinear,
+                Some(0.1),
+                Some(0.2),
+                Some(0.3),
+                Some(0.4),
+            ),
         ),
         (
             "color(display-p3 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(PredefinedColorSpace::DisplayP3, 0.1, 0.2, 0.3, 0.4),
+            OutputType::ColorFunction(
+                PredefinedColorSpace::DisplayP3,
+                Some(0.1),
+                Some(0.2),
+                Some(0.3),
+                Some(0.4),
+            ),
         ),
         (
             "color(a98-rgb 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(PredefinedColorSpace::A98Rgb, 0.1, 0.2, 0.3, 0.4),
+            OutputType::ColorFunction(
+                PredefinedColorSpace::A98Rgb,
+                Some(0.1),
+                Some(0.2),
+                Some(0.3),
+                Some(0.4),
+            ),
         ),
         (
             "color(prophoto-rgb 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(PredefinedColorSpace::ProphotoRgb, 0.1, 0.2, 0.3, 0.4),
+            OutputType::ColorFunction(
+                PredefinedColorSpace::ProphotoRgb,
+                Some(0.1),
+                Some(0.2),
+                Some(0.3),
+                Some(0.4),
+            ),
         ),
         (
             "color(rec2020 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(PredefinedColorSpace::Rec2020, 0.1, 0.2, 0.3, 0.4),
+            OutputType::ColorFunction(
+                PredefinedColorSpace::Rec2020,
+                Some(0.1),
+                Some(0.2),
+                Some(0.3),
+                Some(0.4),
+            ),
         ),
         (
             "color(xyz-d50 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(PredefinedColorSpace::XyzD50, 0.1, 0.2, 0.3, 0.4),
+            OutputType::ColorFunction(
+                PredefinedColorSpace::XyzD50,
+                Some(0.1),
+                Some(0.2),
+                Some(0.3),
+                Some(0.4),
+            ),
         ),
         (
             "color(xyz-d65 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(PredefinedColorSpace::XyzD65, 0.1, 0.2, 0.3, 0.4),
+            OutputType::ColorFunction(
+                PredefinedColorSpace::XyzD65,
+                Some(0.1),
+                Some(0.2),
+                Some(0.3),
+                Some(0.4),
+            ),
+        ),
+        (
+            "color(srgb none none none)",
+            OutputType::ColorFunction(PredefinedColorSpace::Srgb, None, None, None, Some(1.0)),
+        ),
+        (
+            "color(srgb none none none / none)",
+            OutputType::ColorFunction(PredefinedColorSpace::Srgb, None, None, None, None),
         ),
     ];
 
@@ -1644,7 +1744,7 @@ fn generic_parser() {
         let mut input = ParserInput::new(*input);
         let mut input = Parser::new(&mut input);
 
-        let actual: OutputType = parse_color_with(&ComponentParser, &mut input).unwrap();
+        let actual: OutputType = parse_color_with(&TestColorParser, &mut input).unwrap();
         assert_eq!(actual, *expected);
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1618,6 +1618,7 @@ fn generic_parser() {
         ("currentColor", OutputType::CurrentColor),
         ("rgb(1, 2, 3)", OutputType::Rgba(1, 2, 3, 1.0)),
         ("rgba(1, 2, 3, 0.4)", OutputType::Rgba(1, 2, 3, 0.4)),
+        ("rgb(none none none / none)", OutputType::Rgba(0, 0, 0, 0.0)),
         (
             "hsla(45deg, 20%, 30%, 0.4)",
             OutputType::Hsl(Some(45.0), Some(0.2), Some(0.3), Some(0.4)),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1519,7 +1519,7 @@ fn generic_parser() {
     enum OutputType {
         CurrentColor,
         Rgba(u8, u8, u8, f32),
-        Hsl(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
+        Hsl(f32, f32, f32, f32),
         Hwb(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
         Lab(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
         Lch(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
@@ -1543,12 +1543,7 @@ fn generic_parser() {
             OutputType::Rgba(red, green, blue, alpha)
         }
 
-        fn from_hsl(
-            hue: Option<f32>,
-            saturation: Option<f32>,
-            lightness: Option<f32>,
-            alpha: Option<f32>,
-        ) -> Self {
+        fn from_hsl(hue: f32, saturation: f32, lightness: f32, alpha: f32) -> Self {
             OutputType::Hsl(hue, saturation, lightness, alpha)
         }
 
@@ -1619,17 +1614,15 @@ fn generic_parser() {
         ("rgb(1, 2, 3)", OutputType::Rgba(1, 2, 3, 1.0)),
         ("rgba(1, 2, 3, 0.4)", OutputType::Rgba(1, 2, 3, 0.4)),
         ("rgb(none none none / none)", OutputType::Rgba(0, 0, 0, 0.0)),
+        ("rgb(1 none 3 / none)", OutputType::Rgba(1, 0, 3, 0.0)),
         (
             "hsla(45deg, 20%, 30%, 0.4)",
-            OutputType::Hsl(Some(45.0), Some(0.2), Some(0.3), Some(0.4)),
+            OutputType::Hsl(45.0, 0.2, 0.3, 0.4),
         ),
-        (
-            "hsl(45deg none none)",
-            OutputType::Hsl(Some(45.0), None, None, Some(1.0)),
-        ),
+        ("hsl(45deg none none)", OutputType::Hsl(45.0, 0.0, 0.0, 1.0)),
         (
             "hsl(none 10% none / none)",
-            OutputType::Hsl(None, Some(0.1), None, None),
+            OutputType::Hsl(0.0, 0.1, 0.0, 0.0),
         ),
         (
             "hwb(45deg 20% 30% / 0.4)",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1625,6 +1625,10 @@ fn generic_parser() {
             OutputType::Hsl(0.0, 0.1, 0.0, 0.0),
         ),
         (
+            "hsl(120 100.0% 50.0%)",
+            OutputType::Hsl(120.0, 1.0, 0.5, 1.0),
+        ),
+        (
             "hwb(45deg 20% 30% / 0.4)",
             OutputType::Hwb(Some(45.0), Some(0.2), Some(0.3), Some(0.4)),
         ),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1519,7 +1519,7 @@ fn generic_parser() {
     enum OutputType {
         CurrentColor,
         Rgba(u8, u8, u8, f32),
-        Hsl(f32, f32, f32, f32),
+        Hsl(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
         Hwb(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
         Lab(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
         Lch(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
@@ -1543,7 +1543,12 @@ fn generic_parser() {
             OutputType::Rgba(red, green, blue, alpha)
         }
 
-        fn from_hsl(hue: f32, saturation: f32, lightness: f32, alpha: f32) -> Self {
+        fn from_hsl(
+            hue: Option<f32>,
+            saturation: Option<f32>,
+            lightness: Option<f32>,
+            alpha: Option<f32>,
+        ) -> Self {
             OutputType::Hsl(hue, saturation, lightness, alpha)
         }
 
@@ -1609,133 +1614,37 @@ fn generic_parser() {
         type Error = ();
     }
 
+    #[rustfmt::skip]
     const TESTS: &[(&str, OutputType)] = &[
-        ("currentColor", OutputType::CurrentColor),
-        ("rgb(1, 2, 3)", OutputType::Rgba(1, 2, 3, 1.0)),
-        ("rgba(1, 2, 3, 0.4)", OutputType::Rgba(1, 2, 3, 0.4)),
-        ("rgb(none none none / none)", OutputType::Rgba(0, 0, 0, 0.0)),
-        ("rgb(1 none 3 / none)", OutputType::Rgba(1, 0, 3, 0.0)),
-        (
-            "hsla(45deg, 20%, 30%, 0.4)",
-            OutputType::Hsl(45.0, 0.2, 0.3, 0.4),
-        ),
-        ("hsl(45deg none none)", OutputType::Hsl(45.0, 0.0, 0.0, 1.0)),
-        (
-            "hsl(none 10% none / none)",
-            OutputType::Hsl(0.0, 0.1, 0.0, 0.0),
-        ),
-        (
-            "hsl(120 100.0% 50.0%)",
-            OutputType::Hsl(120.0, 1.0, 0.5, 1.0),
-        ),
-        (
-            "hwb(45deg 20% 30% / 0.4)",
-            OutputType::Hwb(Some(45.0), Some(0.2), Some(0.3), Some(0.4)),
-        ),
-        (
-            "lab(100 20 30 / 0.4)",
-            OutputType::Lab(Some(100.0), Some(20.0), Some(30.0), Some(0.4)),
-        ),
-        (
-            "lch(100 20 30 / 0.4)",
-            OutputType::Lch(Some(100.0), Some(20.0), Some(30.0), Some(0.4)),
-        ),
-        (
-            "oklab(100 20 30 / 0.4)",
-            OutputType::Oklab(Some(100.0), Some(20.0), Some(30.0), Some(0.4)),
-        ),
-        (
-            "oklch(100 20 30 / 0.4)",
-            OutputType::Oklch(Some(100.0), Some(20.0), Some(30.0), Some(0.4)),
-        ),
-        (
-            "color(srgb 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(
-                PredefinedColorSpace::Srgb,
-                Some(0.1),
-                Some(0.2),
-                Some(0.3),
-                Some(0.4),
-            ),
-        ),
-        (
-            "color(srgb-linear 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(
-                PredefinedColorSpace::SrgbLinear,
-                Some(0.1),
-                Some(0.2),
-                Some(0.3),
-                Some(0.4),
-            ),
-        ),
-        (
-            "color(display-p3 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(
-                PredefinedColorSpace::DisplayP3,
-                Some(0.1),
-                Some(0.2),
-                Some(0.3),
-                Some(0.4),
-            ),
-        ),
-        (
-            "color(a98-rgb 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(
-                PredefinedColorSpace::A98Rgb,
-                Some(0.1),
-                Some(0.2),
-                Some(0.3),
-                Some(0.4),
-            ),
-        ),
-        (
-            "color(prophoto-rgb 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(
-                PredefinedColorSpace::ProphotoRgb,
-                Some(0.1),
-                Some(0.2),
-                Some(0.3),
-                Some(0.4),
-            ),
-        ),
-        (
-            "color(rec2020 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(
-                PredefinedColorSpace::Rec2020,
-                Some(0.1),
-                Some(0.2),
-                Some(0.3),
-                Some(0.4),
-            ),
-        ),
-        (
-            "color(xyz-d50 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(
-                PredefinedColorSpace::XyzD50,
-                Some(0.1),
-                Some(0.2),
-                Some(0.3),
-                Some(0.4),
-            ),
-        ),
-        (
-            "color(xyz-d65 0.1 0.2 0.3 / 0.4)",
-            OutputType::ColorFunction(
-                PredefinedColorSpace::XyzD65,
-                Some(0.1),
-                Some(0.2),
-                Some(0.3),
-                Some(0.4),
-            ),
-        ),
-        (
-            "color(srgb none none none)",
-            OutputType::ColorFunction(PredefinedColorSpace::Srgb, None, None, None, Some(1.0)),
-        ),
-        (
-            "color(srgb none none none / none)",
-            OutputType::ColorFunction(PredefinedColorSpace::Srgb, None, None, None, None),
-        ),
+        ("currentColor",                OutputType::CurrentColor),
+        ("rgb(1, 2, 3)",                OutputType::Rgba(1, 2, 3, 1.0)),
+        ("rgba(1, 2, 3, 0.4)",          OutputType::Rgba(1, 2, 3, 0.4)),
+        ("rgb(none none none / none)",  OutputType::Rgba(0, 0, 0, 0.0)),
+        ("rgb(1 none 3 / none)",        OutputType::Rgba(1, 0, 3, 0.0)),
+        
+        ("hsla(45deg, 20%, 30%, 0.4)",  OutputType::Hsl(Some(45.0), Some(0.2), Some(0.3), Some(0.4))),
+        ("hsl(45deg none none)",        OutputType::Hsl(Some(45.0), None, None, Some(1.0))),
+        ("hsl(none 10% none / none)",   OutputType::Hsl(None, Some(0.1), None, None)),
+        ("hsl(120 100.0% 50.0%)",       OutputType::Hsl(Some(120.0), Some(1.0), Some(0.5), Some(1.0))),
+        
+        ("hwb(45deg 20% 30% / 0.4)",    OutputType::Hwb(Some(45.0), Some(0.2), Some(0.3), Some(0.4))),
+        
+        ("lab(100 20 30 / 0.4)",        OutputType::Lab(Some(100.0), Some(20.0), Some(30.0), Some(0.4))),
+        ("lch(100 20 30 / 0.4)",        OutputType::Lch(Some(100.0), Some(20.0), Some(30.0), Some(0.4))),
+        
+        ("oklab(100 20 30 / 0.4)",      OutputType::Oklab(Some(100.0), Some(20.0), Some(30.0), Some(0.4))),
+        ("oklch(100 20 30 / 0.4)",      OutputType::Oklch(Some(100.0), Some(20.0), Some(30.0), Some(0.4))),
+        
+        ("color(srgb 0.1 0.2 0.3 / 0.4)",           OutputType::ColorFunction(PredefinedColorSpace::Srgb, Some(0.1), Some(0.2), Some(0.3), Some(0.4))),
+        ("color(srgb none none none)",              OutputType::ColorFunction(PredefinedColorSpace::Srgb, None, None, None, Some(1.0))),
+        ("color(srgb none none none / none)",       OutputType::ColorFunction(PredefinedColorSpace::Srgb, None, None, None, None)),
+        ("color(srgb-linear 0.1 0.2 0.3 / 0.4)",    OutputType::ColorFunction(PredefinedColorSpace::SrgbLinear, Some(0.1), Some(0.2), Some(0.3), Some(0.4))),
+        ("color(display-p3 0.1 0.2 0.3 / 0.4)",     OutputType::ColorFunction(PredefinedColorSpace::DisplayP3, Some(0.1), Some(0.2), Some(0.3), Some(0.4))),
+        ("color(a98-rgb 0.1 0.2 0.3 / 0.4)",        OutputType::ColorFunction(PredefinedColorSpace::A98Rgb, Some(0.1), Some(0.2), Some(0.3), Some(0.4))),
+        ("color(prophoto-rgb 0.1 0.2 0.3 / 0.4)",   OutputType::ColorFunction(PredefinedColorSpace::ProphotoRgb, Some(0.1), Some(0.2), Some(0.3), Some(0.4))),
+        ("color(rec2020 0.1 0.2 0.3 / 0.4)",        OutputType::ColorFunction(PredefinedColorSpace::Rec2020, Some(0.1), Some(0.2), Some(0.3), Some(0.4))),
+        ("color(xyz-d50 0.1 0.2 0.3 / 0.4)",        OutputType::ColorFunction(PredefinedColorSpace::XyzD50, Some(0.1), Some(0.2), Some(0.3), Some(0.4))),
+        ("color(xyz-d65 0.1 0.2 0.3 / 0.4)",        OutputType::ColorFunction(PredefinedColorSpace::XyzD65, Some(0.1), Some(0.2), Some(0.3), Some(0.4))),
     ];
 
     for (input, expected) in TESTS {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -592,19 +592,19 @@ fn serialize_current_color() {
 
 #[test]
 fn serialize_rgb_full_alpha() {
-    let c = Color::Rgba(RGBA::new(255, 230, 204, 1.0));
+    let c = Color::Rgba(RGBA::new(Some(255), Some(230), Some(204), Some(1.0)));
     assert_eq!(c.to_css_string(), "rgb(255, 230, 204)");
 }
 
 #[test]
 fn serialize_rgba() {
-    let c = Color::Rgba(RGBA::new(26, 51, 77, 0.125));
+    let c = Color::Rgba(RGBA::new(Some(26), Some(51), Some(77), Some(0.125)));
     assert_eq!(c.to_css_string(), "rgba(26, 51, 77, 0.125)");
 }
 
 #[test]
 fn serialize_rgba_two_digit_float_if_roundtrips() {
-    let c = Color::Rgba(RGBA::from_floats(0., 0., 0., 0.5));
+    let c = Color::Rgba(RGBA::from_floats(Some(0.), Some(0.), Some(0.), Some(0.5)));
     assert_eq!(c.to_css_string(), "rgba(0, 0, 0, 0.5)");
 }
 
@@ -1518,7 +1518,7 @@ fn generic_parser() {
     #[derive(Debug, PartialEq)]
     enum OutputType {
         CurrentColor,
-        Rgba(u8, u8, u8, f32),
+        Rgba(Option<u8>, Option<u8>, Option<u8>, Option<f32>),
         Hsl(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
         Hwb(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
         Lab(Option<f32>, Option<f32>, Option<f32>, Option<f32>),
@@ -1539,7 +1539,12 @@ fn generic_parser() {
             OutputType::CurrentColor
         }
 
-        fn from_rgba(red: u8, green: u8, blue: u8, alpha: f32) -> Self {
+        fn from_rgba(
+            red: Option<u8>,
+            green: Option<u8>,
+            blue: Option<u8>,
+            alpha: Option<f32>,
+        ) -> Self {
             OutputType::Rgba(red, green, blue, alpha)
         }
 
@@ -1617,10 +1622,10 @@ fn generic_parser() {
     #[rustfmt::skip]
     const TESTS: &[(&str, OutputType)] = &[
         ("currentColor",                OutputType::CurrentColor),
-        ("rgb(1, 2, 3)",                OutputType::Rgba(1, 2, 3, 1.0)),
-        ("rgba(1, 2, 3, 0.4)",          OutputType::Rgba(1, 2, 3, 0.4)),
-        ("rgb(none none none / none)",  OutputType::Rgba(0, 0, 0, 0.0)),
-        ("rgb(1 none 3 / none)",        OutputType::Rgba(1, 0, 3, 0.0)),
+        ("rgb(1, 2, 3)",                OutputType::Rgba(Some(1), Some(2), Some(3), Some(1.0))),
+        ("rgba(1, 2, 3, 0.4)",          OutputType::Rgba(Some(1), Some(2), Some(3), Some(0.4))),
+        ("rgb(none none none / none)",  OutputType::Rgba(None, None, None, None)),
+        ("rgb(1 none 3 / none)",        OutputType::Rgba(Some(1), None, Some(3), None)),
         
         ("hsla(45deg, 20%, 30%, 0.4)",  OutputType::Hsl(Some(45.0), Some(0.2), Some(0.3), Some(0.4))),
         ("hsl(45deg none none)",        OutputType::Hsl(Some(45.0), None, None, Some(1.0))),


### PR DESCRIPTION
For each color component, we allow the "none" keyword.  The keyword will be kept in place for serialization.  The "none" keyword is not allowed in the legacy syntax.

`rgb` and `hsl` are handled special, because they support the legacy color syntax.  They also cannot be combined, because rgb cares about the type of the components, and hsl does not.