### PR TITLE
Combine parsing into legacy and new parsing.

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -540,10 +540,10 @@ impl NumberOrPercentage {
         }
     }
 
-    fn value(&self, percentage_max: f32) -> f32 {
+    fn value(&self, percentage_basis: f32) -> f32 {
         match *self {
             Self::Number { value } => value,
-            Self::Percentage { unit_value } => unit_value * percentage_max,
+            Self::Percentage { unit_value } => unit_value * percentage_basis,
         }
     }
 }


### PR DESCRIPTION
Combine the rules of legacy and new parsing into single functions.  This allows for a much clearer separation of which keywords support which syntax.  RGB is still special, because it the components **must** be of the same type (numbers or percentages).  Most of the color functions are using the new syntax, but some special notes:

- `RGB` uses it's own parser as mentioned.
- `HSL` supports both legacy and new syntax.
- `HWB` only supports new suntax.
- _ the rest supports the new syntax only.

These changes are also in preparation of introducing the `none` keyword where it is much more important to know which syntax is being used, as legacy syntax does **not** support the `none` keyword.