### PR TITLE
Cleanup for crates.io release

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -60,7 +60,6 @@ fn normalize_hue(hue: f32) -> f32 {
 
 /// A color with red, green, blue, and alpha components, in a byte each.
 #[derive(Clone, Copy, PartialEq, Debug)]
-#[repr(C)]
 pub struct RGBA {
     /// The red component.
     pub red: Option<u8>,
@@ -287,7 +286,6 @@ impl<'de> Deserialize<'de> for Hwb {
 
 /// Color specified by lightness, a- and b-axis components.
 #[derive(Clone, Copy, PartialEq, Debug)]
-#[repr(C)]
 pub struct Lab {
     /// The lightness component.
     pub lightness: Option<f32>,
@@ -301,7 +299,6 @@ pub struct Lab {
 
 /// Color specified by lightness, a- and b-axis components.
 #[derive(Clone, Copy, PartialEq, Debug)]
-#[repr(C)]
 pub struct Oklab {
     /// The lightness component.
     pub lightness: Option<f32>,
@@ -380,7 +377,6 @@ impl_lab_like!(Oklab, "oklab");
 
 /// Color specified by lightness, chroma and hue components.
 #[derive(Clone, Copy, PartialEq, Debug)]
-#[repr(C)]
 pub struct Lch {
     /// The lightness component.
     pub lightness: Option<f32>,
@@ -394,7 +390,6 @@ pub struct Lch {
 
 /// Color specified by lightness, chroma and hue components.
 #[derive(Clone, Copy, PartialEq, Debug)]
-#[repr(C)]
 pub struct Oklch {
     /// The lightness component.
     pub lightness: Option<f32>,

--- a/src/color.rs
+++ b/src/color.rs
@@ -150,6 +150,7 @@ impl ToCss for RGBA {
     }
 }
 
+/// Color specified by hue, saturation and lightness components.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Hsl {
     /// The hue component.
@@ -215,6 +216,7 @@ impl<'de> Deserialize<'de> for Hsl {
     }
 }
 
+/// Color specified by hue, whiteness and blackness components.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Hwb {
     /// The hue component.

--- a/src/color.rs
+++ b/src/color.rs
@@ -585,7 +585,12 @@ impl ToCss for ColorFunction {
     }
 }
 
-/// A <color> value.
+/// Describes one of the value <color> values according to the CSS
+/// specification.
+///
+/// Most components are `Option<_>`, so when the value is `None`, that component
+/// serializes to the "none" keyword.
+///
 /// https://drafts.csswg.org/css-color-4/#color-type
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Color {

--- a/src/color.rs
+++ b/src/color.rs
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Allow text like <color> in docs.
+#![allow(rustdoc::invalid_html_tags)]
+
 use std::f32::consts::PI;
 use std::fmt;
 use std::str::FromStr;
@@ -23,7 +26,7 @@ where
     }
 }
 
-/// https://drafts.csswg.org/css-color-4/#serializing-alpha-values
+/// <https://drafts.csswg.org/css-color-4/#serializing-alpha-values>
 #[inline]
 fn serialize_alpha(
     dest: &mut impl fmt::Write,
@@ -53,7 +56,7 @@ fn serialize_alpha(
 
 // Guaratees hue in [0..360)
 fn normalize_hue(hue: f32) -> f32 {
-    // https://drafts.csswg.org/css-values/#angles
+    // <https://drafts.csswg.org/css-values/#angles>
     // Subtract an integer before rounding, to avoid some rounding errors:
     hue - 360.0 * (hue / 360.0).floor()
 }
@@ -466,24 +469,24 @@ impl_lch_like!(Lch, "lch");
 impl_lch_like!(Oklch, "oklch");
 
 /// A Predefined color space specified in:
-/// https://drafts.csswg.org/css-color-4/#predefined
+/// <https://drafts.csswg.org/css-color-4/#predefined>
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum PredefinedColorSpace {
-    /// https://drafts.csswg.org/css-color-4/#predefined-sRGB
+    /// <https://drafts.csswg.org/css-color-4/#predefined-sRGB>
     Srgb,
-    /// https://drafts.csswg.org/css-color-4/#predefined-sRGB-linear
+    /// <https://drafts.csswg.org/css-color-4/#predefined-sRGB-linear>
     SrgbLinear,
-    /// https://drafts.csswg.org/css-color-4/#predefined-display-p3
+    /// <https://drafts.csswg.org/css-color-4/#predefined-display-p3>
     DisplayP3,
-    /// https://drafts.csswg.org/css-color-4/#predefined-a98-rgb
+    /// <https://drafts.csswg.org/css-color-4/#predefined-a98-rgb>
     A98Rgb,
-    /// https://drafts.csswg.org/css-color-4/#predefined-prophoto-rgb
+    /// <https://drafts.csswg.org/css-color-4/#predefined-prophoto-rgb>
     ProphotoRgb,
-    /// https://drafts.csswg.org/css-color-4/#predefined-rec2020
+    /// <https://drafts.csswg.org/css-color-4/#predefined-rec2020>
     Rec2020,
-    /// https://drafts.csswg.org/css-color-4/#predefined-xyz
+    /// <https://drafts.csswg.org/css-color-4/#predefined-xyz>
     XyzD50,
-    /// https://drafts.csswg.org/css-color-4/#predefined-xyz
+    /// <https://drafts.csswg.org/css-color-4/#predefined-xyz>
     XyzD65,
 }
 
@@ -532,7 +535,7 @@ impl ToCss for PredefinedColorSpace {
 }
 
 /// A color specified by the color() function.
-/// https://drafts.csswg.org/css-color-4/#color-function
+/// <https://drafts.csswg.org/css-color-4/#color-function>
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct ColorFunction {
     /// The color space for this color.
@@ -593,7 +596,7 @@ impl ToCss for ColorFunction {
 /// Most components are `Option<_>`, so when the value is `None`, that component
 /// serializes to the "none" keyword.
 ///
-/// https://drafts.csswg.org/css-color-4/#color-type
+/// <https://drafts.csswg.org/css-color-4/#color-type>
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Color {
     /// The 'currentcolor' keyword.
@@ -881,8 +884,8 @@ where
     })
 }
 
-/// Parse a CSS color with the specified [`ColorComponentParser`] and return a
-/// new color value on success.
+/// Parse a CSS color using the specified [`ColorParser`] and return a new color
+/// value on success.
 pub fn parse_color_with<'i, 't, P>(
     color_parser: &P,
     input: &mut Parser<'i, 't>,
@@ -1179,12 +1182,12 @@ fn clamp_unit_f32(val: f32) -> u8 {
     // Chrome does something similar for the alpha value, but not
     // the rgb values.
     //
-    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1340484
+    // See <https://bugzilla.mozilla.org/show_bug.cgi?id=1340484>
     //
     // Clamping to 256 and rounding after would let 1.0 map to 256, and
     // `256.0_f32 as u8` is undefined behavior:
     //
-    // https://github.com/rust-lang/rust/issues/10184
+    // <https://github.com/rust-lang/rust/issues/10184>
     clamp_floor_256_f32(val * 255.)
 }
 
@@ -1353,7 +1356,7 @@ where
 
 /// Parses hsl syntax.
 ///
-/// https://drafts.csswg.org/css-color/#the-hsl-notation
+/// <https://drafts.csswg.org/css-color/#the-hsl-notation>
 #[inline]
 fn parse_hsl<'i, 't, P>(
     color_parser: &P,
@@ -1392,7 +1395,7 @@ where
 
 /// Parses hwb syntax.
 ///
-/// https://drafts.csswg.org/css-color/#the-hbw-notation
+/// <https://drafts.csswg.org/css-color/#the-hbw-notation>
 #[inline]
 fn parse_hwb<'i, 't, P>(
     color_parser: &P,
@@ -1416,7 +1419,7 @@ where
     Ok(P::Output::from_hwb(hue, whiteness, blackness, alpha))
 }
 
-/// https://drafts.csswg.org/css-color-4/#hwb-to-rgb
+/// <https://drafts.csswg.org/css-color-4/#hwb-to-rgb>
 #[inline]
 pub fn hwb_to_rgb(h: f32, w: f32, b: f32) -> (f32, f32, f32) {
     if w + b >= 1.0 {
@@ -1433,7 +1436,7 @@ pub fn hwb_to_rgb(h: f32, w: f32, b: f32) -> (f32, f32, f32) {
     (red, green, blue)
 }
 
-/// https://drafts.csswg.org/css-color/#hsl-color
+/// <https://drafts.csswg.org/css-color/#hsl-color>
 /// except with h pre-multiplied by 3, to avoid some rounding errors.
 #[inline]
 pub fn hsl_to_rgb(hue: f32, saturation: f32, lightness: f32) -> (f32, f32, f32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,8 @@ fn parse_border_spacing(_context: &ParserContext, input: &mut Parser)
 
 pub use crate::color::{
     hsl_to_rgb, hwb_to_rgb, parse_color_keyword, parse_color_with, parse_hash_color, AngleOrNumber,
-    Color, ColorFunction, ColorParser, FromParsedColor, Lab, Lch, NumberOrPercentage, Oklab, Oklch,
-    PredefinedColorSpace, RGBA,
+    Color, ColorFunction, ColorParser, FromParsedColor, Hsl, Hwb, Lab, Lch, NumberOrPercentage,
+    Oklab, Oklch, PredefinedColorSpace, RGBA,
 };
 pub use crate::cow_rc_str::CowRcStr;
 pub use crate::from_bytes::{stylesheet_encoding, EncodingSupport};


### PR DESCRIPTION
- Add documentation where needed.
- Remove #[repr(C)] from structs.  These are not needed any more and doesn't really do anything now that the types are Option<_>.
- Fix links so that they work in docs.
- Small clippy fixes.

@emilio For publishing all the new color changes as 0.30 to crates.io, any other suggestions on what to clean up?