### PR TITLE
Encapsulate unsafe in `_cssparser_internal_to_lowercase` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,9 @@ pub use crate::color::{
 pub use crate::cow_rc_str::CowRcStr;
 pub use crate::from_bytes::{stylesheet_encoding, EncodingSupport};
 #[doc(hidden)]
-pub use crate::macros::_cssparser_internal_to_lowercase;
+pub use crate::macros::{
+    _cssparser_internal_create_uninit_array, _cssparser_internal_to_lowercase,
+};
 pub use crate::nth::parse_nth;
 pub use crate::parser::{BasicParseError, BasicParseErrorKind, ParseError, ParseErrorKind};
 pub use crate::parser::{Delimiter, Delimiters, Parser, ParserInput, ParserState};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -131,8 +131,7 @@ pub fn _cssparser_internal_create_uninit_array<const N: usize>() -> [MaybeUninit
 #[doc(hidden)]
 macro_rules! _cssparser_internal_to_lowercase {
     ($input: expr, $BUFFER_SIZE: expr => $output: ident) => {
-        const BUFFER_SIZE: usize = $BUFFER_SIZE as usize;
-        let mut buffer = $crate::macros::_cssparser_internal_create_uninit_array::<BUFFER_SIZE>();
+        let mut buffer = $crate::_cssparser_internal_create_uninit_array::<{ $BUFFER_SIZE }>();
         let input: &str = $input;
         let $output = $crate::_cssparser_internal_to_lowercase(&mut buffer, input);
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -110,6 +110,16 @@ macro_rules! ascii_case_insensitive_phf_map {
     }
 }
 
+/// Create a new array of MaybeUninit<T> items, in an uninitialized state.
+#[inline(always)]
+pub fn _cssparser_internal_create_uninit_array<const N: usize>() -> [MaybeUninit<u8>; N] {
+    unsafe {
+        // SAFETY: An uninitialized `[MaybeUninit<_>; LEN]` is valid.
+        // See: https://doc.rust-lang.org/stable/core/mem/union.MaybeUninit.html#method.uninit_array
+        MaybeUninit::<[MaybeUninit<u8>; N]>::uninit().assume_init()
+    }
+}
+
 /// Implementation detail of match_ignore_ascii_case! and ascii_case_insensitive_phf_map! macros.
 ///
 /// **This macro is not part of the public API. It can change or be removed between any versions.**
@@ -121,19 +131,8 @@ macro_rules! ascii_case_insensitive_phf_map {
 #[doc(hidden)]
 macro_rules! _cssparser_internal_to_lowercase {
     ($input: expr, $BUFFER_SIZE: expr => $output: ident) => {
-        /// Create a new array of MaybeUninit<T> items, in an uninitialized state.
-        #[inline(always)]
-        fn create_uninit_array<const N: usize>() -> [::std::mem::MaybeUninit<u8>; N] {
-            unsafe {
-                // SAFETY: An uninitialized `[MaybeUninit<_>; LEN]` is valid.
-                // See: https://doc.rust-lang.org/stable/core/mem/union.MaybeUninit.html#method.uninit_array
-                ::std::mem::MaybeUninit::<[::std::mem::MaybeUninit<u8>; N]>::uninit()
-                    .assume_init()
-            }
-        }
-
         const BUFFER_SIZE: usize = $BUFFER_SIZE as usize;
-        let mut buffer = create_uninit_array::<BUFFER_SIZE>();
+        let mut buffer = $crate::macros::_cssparser_internal_create_uninit_array::<BUFFER_SIZE>();
         let input: &str = $input;
         let $output = $crate::_cssparser_internal_to_lowercase(&mut buffer, input);
     };


### PR DESCRIPTION
# Objective

- Allow the `_cssparser_internal_to_lowercase` macro to be used in crates that set `#[forbid(unsafe)]`.
- Document the safety invariant for this unsafe block

## Changes made

- Wrap the `unsafe` block in the `_cssparser_internal_to_lowercase` macro in an `#[inline(always)]` function.
-  Add comments

## Context

- https://github.com/DioxusLabs/taffy/pull/460#discussion_r1174152707