### PR TITLE
Make the serialize_alpha function public.

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -26,9 +26,10 @@ where
     }
 }
 
+/// Serialize the alpha copmonent of a color according to the specification.
 /// <https://drafts.csswg.org/css-color-4/#serializing-alpha-values>
 #[inline]
-fn serialize_alpha(
+pub fn serialize_color_alpha(
     dest: &mut impl fmt::Write,
     alpha: Option<f32>,
     legacy_syntax: bool,
@@ -146,7 +147,7 @@ impl ToCss for RGBA {
         self.blue.unwrap_or(0).to_css(dest)?;
 
         // Legacy syntax does not allow none components.
-        serialize_alpha(dest, Some(self.alpha.unwrap_or(0.0)), true)?;
+        serialize_color_alpha(dest, Some(self.alpha.unwrap_or(0.0)), true)?;
 
         dest.write_char(')')
     }
@@ -367,7 +368,7 @@ macro_rules! impl_lab_like {
                 serialize_none_or(dest, &self.a)?;
                 dest.write_char(' ')?;
                 serialize_none_or(dest, &self.b)?;
-                serialize_alpha(dest, self.alpha, false)?;
+                serialize_color_alpha(dest, self.alpha, false)?;
                 dest.write_char(')')
             }
         }
@@ -458,7 +459,7 @@ macro_rules! impl_lch_like {
                 serialize_none_or(dest, &self.chroma)?;
                 dest.write_char(' ')?;
                 serialize_none_or(dest, &self.hue)?;
-                serialize_alpha(dest, self.alpha, false)?;
+                serialize_color_alpha(dest, self.alpha, false)?;
                 dest.write_char(')')
             }
         }
@@ -584,7 +585,7 @@ impl ToCss for ColorFunction {
         dest.write_char(' ')?;
         serialize_none_or(dest, &self.c3)?;
 
-        serialize_alpha(dest, self.alpha, false)?;
+        serialize_color_alpha(dest, self.alpha, false)?;
 
         dest.write_char(')')
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,9 @@ fn parse_border_spacing(_context: &ParserContext, input: &mut Parser)
 #![recursion_limit = "200"] // For color::parse_color_keyword
 
 pub use crate::color::{
-    hsl_to_rgb, hwb_to_rgb, parse_color_keyword, parse_color_with, parse_hash_color, AngleOrNumber,
-    Color, ColorFunction, ColorParser, FromParsedColor, Hsl, Hwb, Lab, Lch, NumberOrPercentage,
-    Oklab, Oklch, PredefinedColorSpace, RGBA,
+    hsl_to_rgb, hwb_to_rgb, parse_color_keyword, parse_color_with, parse_hash_color,
+    serialize_color_alpha, AngleOrNumber, Color, ColorFunction, ColorParser, FromParsedColor, Hsl,
+    Hwb, Lab, Lch, NumberOrPercentage, Oklab, Oklch, PredefinedColorSpace, RGBA,
 };
 pub use crate::cow_rc_str::CowRcStr;
 pub use crate::from_bytes::{stylesheet_encoding, EncodingSupport};
@@ -84,7 +84,7 @@ pub use crate::parser::{Delimiter, Delimiters, Parser, ParserInput, ParserState}
 pub use crate::rules_and_declarations::{parse_important, parse_one_declaration};
 pub use crate::rules_and_declarations::{parse_one_rule, StyleSheetParser};
 pub use crate::rules_and_declarations::{AtRuleParser, QualifiedRuleParser};
-pub use crate::rules_and_declarations::{RuleBodyParser, RuleBodyItemParser, DeclarationParser};
+pub use crate::rules_and_declarations::{DeclarationParser, RuleBodyItemParser, RuleBodyParser};
 pub use crate::serializer::{serialize_identifier, serialize_name, serialize_string};
 pub use crate::serializer::{CssStringWriter, ToCss, TokenSerializationType};
 pub use crate::tokenizer::{SourceLocation, SourcePosition, Token};


### PR DESCRIPTION
This function is very handy in other places and is worth making public.  Right now it will be used to generate specified value colors in Gecko.