### PR TITLE
Remove build dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,6 @@ phf = {version = ">=0.8,<=0.11", features = ["macros"]}
 serde = {version = "1.0", optional = true}
 smallvec = "1.0"
 
-[build-dependencies]
-syn = { version = "1", features = ["extra-traits", "fold", "full"] }
-quote = "1"
-proc-macro2 = "1"
-
 [features]
 bench = []
 dummy_match_byte = []


### PR DESCRIPTION
They were used before the separate proc-macro crate was created, but aren't anymore.