### PR TITLE
Run miri on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Cargo miri test
         if: "matrix.toolchain == 'nightly'"
-        run: cargo miri test ${{ matrix.features }}
+        run: cargo miri test --features skip_long_tests ${{ matrix.features }}
 
   build_result:
     name: Result

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           override: true
+          components: ${{ matrix.toolchain == 'nightly' && 'miri,rust-src' || '' }}
 
       - name: Cargo build
         run: cargo build ${{ matrix.features }}
@@ -49,6 +50,10 @@ jobs:
       - name: macros build
         run: cargo build
         working-directory: macros
+
+      - name: Cargo miri test
+        if: "matrix.toolchain == 'nightly'"
+        run: cargo miri test ${{ matrix.features }}
 
   build_result:
     name: Result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ smallvec = "1.0"
 [features]
 bench = []
 dummy_match_byte = []
+# Useful for skipping tests when execution is slow, e.g., under miri
+skip_long_tests = []
 
 [workspace]
 members = [".", "./macros", "./procedural-masquerade"]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -373,6 +373,7 @@ fn color3() {
     })
 }
 
+#[cfg_attr(all(miri, feature = "skip_long_tests"), ignore)]
 #[test]
 fn color3_hsl() {
     run_color_tests(include_str!("css-parsing-tests/color3_hsl.json"), |c| {
@@ -395,6 +396,7 @@ fn color3_keywords() {
     )
 }
 
+#[cfg_attr(all(miri, feature = "skip_long_tests"), ignore)]
 #[test]
 fn color4_hwb() {
     run_color_tests(include_str!("css-parsing-tests/color4_hwb.json"), |c| {
@@ -404,6 +406,7 @@ fn color4_hwb() {
     })
 }
 
+#[cfg_attr(all(miri, feature = "skip_long_tests"), ignore)]
 #[test]
 fn color4_lab_lch_oklab_oklch() {
     run_color_tests(
@@ -939,6 +942,7 @@ fn unquoted_url(b: &mut Bencher) {
     })
 }
 
+#[cfg_attr(all(miri, feature = "skip_long_tests"), ignore)]
 #[cfg(feature = "bench")]
 #[bench]
 fn numeric(b: &mut Bencher) {
@@ -953,6 +957,7 @@ fn numeric(b: &mut Bencher) {
 
 struct JsonParser;
 
+#[cfg_attr(all(miri, feature = "skip_long_tests"), ignore)]
 #[test]
 fn no_stack_overflow_multiple_nested_blocks() {
     let mut input: String = "{{".into();
@@ -1413,6 +1418,7 @@ fn parse_sourceurl_comments() {
     }
 }
 
+#[cfg_attr(all(miri, feature = "skip_long_tests"), ignore)]
 #[test]
 fn roundtrip_percentage_token() {
     fn test_roundtrip(value: &str) {


### PR DESCRIPTION
Resolves #346. Some tests that take over a minute to run under miri are skipped (on CI only):

* color3_hsl
* color4_hwb
* color4_lab_lch_oklab_oklch
* no_stack_overflow_multiple_nested_blocks
* numeric
* roundtrip_percentage_token