### PR TITLE
parser: Remove the line-number-offset mechanism.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -213,15 +213,6 @@ impl<'i> ParserInput<'i> {
         }
     }
 
-    /// Create a new input for a parser.  Line numbers in locations
-    /// are offset by the given value.
-    pub fn new_with_line_number_offset(input: &'i str, first_line_number: u32) -> ParserInput<'i> {
-        ParserInput {
-            tokenizer: Tokenizer::with_first_line_number(input, first_line_number),
-            cached_token: None,
-        }
-    }
-
     #[inline]
     fn cached_token_ref(&self) -> &Token<'i> {
         &self.cached_token.as_ref().unwrap().token

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1289,52 +1289,6 @@ fn parser_maintains_current_line() {
 }
 
 #[test]
-fn parser_with_line_number_offset() {
-    let mut input = ParserInput::new_with_line_number_offset("ident\nident", 72);
-    let mut parser = Parser::new(&mut input);
-    assert_eq!(
-        parser.current_source_location(),
-        SourceLocation {
-            line: 72,
-            column: 1
-        }
-    );
-    assert_eq!(
-        parser.next_including_whitespace_and_comments(),
-        Ok(&Token::Ident("ident".into()))
-    );
-    assert_eq!(
-        parser.current_source_location(),
-        SourceLocation {
-            line: 72,
-            column: 6
-        }
-    );
-    assert_eq!(
-        parser.next_including_whitespace_and_comments(),
-        Ok(&Token::WhiteSpace("\n".into()))
-    );
-    assert_eq!(
-        parser.current_source_location(),
-        SourceLocation {
-            line: 73,
-            column: 1
-        }
-    );
-    assert_eq!(
-        parser.next_including_whitespace_and_comments(),
-        Ok(&Token::Ident("ident".into()))
-    );
-    assert_eq!(
-        parser.current_source_location(),
-        SourceLocation {
-            line: 73,
-            column: 6
-        }
-    );
-}
-
-#[test]
 fn cdc_regression_test() {
     let mut input = ParserInput::new("-->x");
     let mut parser = Parser::new(&mut input);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -230,16 +230,11 @@ enum SeenStatus {
 impl<'a> Tokenizer<'a> {
     #[inline]
     pub fn new(input: &str) -> Tokenizer {
-        Tokenizer::with_first_line_number(input, 0)
-    }
-
-    #[inline]
-    pub fn with_first_line_number(input: &str, first_line_number: u32) -> Tokenizer {
         Tokenizer {
             input,
             position: 0,
             current_line_start_position: 0,
-            current_line_number: first_line_number,
+            current_line_number: 0,
             var_or_env_functions: SeenStatus::DontCare,
             source_map_url: None,
             source_url: None,
@@ -541,7 +536,7 @@ impl SourcePosition {
 /// The line and column number for a given position within the input.
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct SourceLocation {
-    /// The line number, starting at 0 for the first line, unless `with_first_line_number` was used.
+    /// The line number, starting at 0 for the first line.
     pub line: u32,
 
     /// The column number within a line, starting at 1 for first the character of the line.


### PR DESCRIPTION
It can be implemented on top of the parser anyways, and after bug 1847440 we won't use it anymore.