### PR TITLE
parser: Use a lookup table for Delimiter::from_byte.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -314,15 +314,21 @@ impl Delimiters {
 
     #[inline]
     fn from_byte(byte: Option<u8>) -> Delimiters {
+        const TABLE: [Delimiters; 256] = {
+            let mut table = [Delimiter::None; 256];
+            table[b';' as usize] = Delimiter::Semicolon;
+            table[b'!' as usize] = Delimiter::Bang;
+            table[b',' as usize] = Delimiter::Comma;
+            table[b'{' as usize] = Delimiter::CurlyBracketBlock;
+            table[b'}' as usize] = ClosingDelimiter::CloseCurlyBracket;
+            table[b']' as usize] = ClosingDelimiter::CloseSquareBracket;
+            table[b')' as usize] = ClosingDelimiter::CloseParenthesis;
+            table
+        };
+
         match byte {
-            Some(b';') => Delimiter::Semicolon,
-            Some(b'!') => Delimiter::Bang,
-            Some(b',') => Delimiter::Comma,
-            Some(b'{') => Delimiter::CurlyBracketBlock,
-            Some(b'}') => ClosingDelimiter::CloseCurlyBracket,
-            Some(b']') => ClosingDelimiter::CloseSquareBracket,
-            Some(b')') => ClosingDelimiter::CloseParenthesis,
-            _ => Delimiter::None,
+            None => Delimiter::None,
+            Some(b) => TABLE[b as usize],
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -313,7 +313,7 @@ impl Delimiters {
     }
 
     #[inline]
-    fn from_byte(byte: Option<u8>) -> Delimiters {
+    pub(crate) fn from_byte(byte: Option<u8>) -> Delimiters {
         const TABLE: [Delimiters; 256] = {
             let mut table = [Delimiter::None; 256];
             table[b';' as usize] = Delimiter::Semicolon;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,7 @@ use encoding_rs;
 use serde_json::{self, json, Map, Value};
 
 use crate::color::{parse_color_with, FromParsedColor};
-use crate::{ColorParser, PredefinedColorSpace};
+use crate::{ColorParser, PredefinedColorSpace, Delimiters};
 
 #[cfg(feature = "bench")]
 use self::test::Bencher;
@@ -920,6 +920,18 @@ impl<'a> ToJson for CowRcStr<'a> {
         let s: &str = &*self;
         s.to_json()
     }
+}
+
+#[bench]
+#[cfg(feature = "bench")]
+fn delimiter_from_byte(b: &mut Bencher) {
+    b.iter(|| {
+        for _ in 0..1000 {
+            for i in 0..256 {
+                std::hint::black_box(Delimiters::from_byte(Some(i as u8)));
+            }
+        }
+    })
 }
 
 #[cfg(feature = "bench")]


### PR DESCRIPTION
It's faster.