### PR TITLE
Rename `master` branch to `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
   workflow_dispatch:
   merge_group:


### PR DESCRIPTION
This is in line with the policy decided in the TSC.