### PR TITLE
Refactoring, better ability to use `cssparser-color` as a separate crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cssparser"
 version = "0.33.0"
-authors = [ "Simon Sapin <simon.sapin@exyr.org>" ]
+authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 
 description = "Rust implementation of CSS Syntax Level 3"
 documentation = "https://docs.rs/cssparser/"
@@ -20,11 +20,11 @@ difference = "2.0"
 encoding_rs = "0.8"
 
 [dependencies]
-cssparser-macros = {path = "./macros", version = "0.6.1"}
+cssparser-macros = { path = "./macros", version = "0.6.1" }
 dtoa-short = "0.3"
 itoa = "1.0"
-phf = {version = ">=0.8,<=0.11", features = ["macros"]}
-serde = {version = "1.0", optional = true}
+phf = { version = ">=0.8,<=0.11", features = ["macros"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.34.0"
+version = "0.33.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.33.0"
+version = "0.34.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser-color"
-version = "0.2.0"
+version = "0.1.0"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>"]
 description = "Color implementation based on cssparser"
 documentation = "https://docs.rs/cssparser-color/"

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 
 [dependencies]
 cssparser = { path = ".." }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
 serde = ["cssparser/serde", "dep:serde"]

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -12,7 +12,11 @@ edition = "2021"
 path = "lib.rs"
 
 [dependencies]
-cssparser = { version = "0.33", path = ".." }
+cssparser = { path = ".." }
+serde = { version = "1.0", optional = true }
+
+[features]
+serde = ["cssparser/serde", "dep:serde"]
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser-color"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>"]
 description = "Color implementation based on cssparser"
 documentation = "https://docs.rs/cssparser-color/"

--- a/color/lib.rs
+++ b/color/lib.rs
@@ -50,7 +50,7 @@ where
     P: ColorParser<'i>,
 {
     let location = input.current_source_location();
-    let token = input.try_next()?;
+    let token = input.next()?;
     match *token {
         Token::Hash(ref value) | Token::IDHash(ref value) => {
             parse_hash_color(value.as_bytes()).map(|(r, g, b, a)| P::Output::from_rgba(r, g, b, a))
@@ -991,7 +991,7 @@ pub trait ColorParser<'i> {
         input: &mut Parser<'i, 't>,
     ) -> Result<AngleOrNumber, ParseError<'i, Self::Error>> {
         let location = input.current_source_location();
-        Ok(match *input.try_next()? {
+        Ok(match *input.next()? {
             Token::Number { value, .. } => AngleOrNumber::Number { value },
             Token::Dimension {
                 value: v, ref unit, ..
@@ -1036,7 +1036,7 @@ pub trait ColorParser<'i> {
         input: &mut Parser<'i, 't>,
     ) -> Result<NumberOrPercentage, ParseError<'i, Self::Error>> {
         let location = input.current_source_location();
-        Ok(match *input.try_next()? {
+        Ok(match *input.next()? {
             Token::Number { value, .. } => NumberOrPercentage::Number { value },
             Token::Percentage { unit_value, .. } => NumberOrPercentage::Percentage { unit_value },
             ref t => return Err(location.new_unexpected_token_error(t.clone())),

--- a/color/lib.rs
+++ b/color/lib.rs
@@ -50,7 +50,7 @@ where
     P: ColorParser<'i>,
 {
     let location = input.current_source_location();
-    let token = input.next()?;
+    let token = input.try_next()?;
     match *token {
         Token::Hash(ref value) | Token::IDHash(ref value) => {
             parse_hash_color(value.as_bytes()).map(|(r, g, b, a)| P::Output::from_rgba(r, g, b, a))
@@ -1033,7 +1033,7 @@ pub trait ColorParser<'i> {
         input: &mut Parser<'i, 't>,
     ) -> Result<AngleOrNumber, ParseError<'i, Self::Error>> {
         let location = input.current_source_location();
-        Ok(match *input.next()? {
+        Ok(match *input.try_next()? {
             Token::Number { value, .. } => AngleOrNumber::Number { value },
             Token::Dimension {
                 value: v, ref unit, ..
@@ -1078,7 +1078,7 @@ pub trait ColorParser<'i> {
         input: &mut Parser<'i, 't>,
     ) -> Result<NumberOrPercentage, ParseError<'i, Self::Error>> {
         let location = input.current_source_location();
-        Ok(match *input.next()? {
+        Ok(match *input.try_next()? {
             Token::Number { value, .. } => NumberOrPercentage::Number { value },
             Token::Percentage { unit_value, .. } => NumberOrPercentage::Percentage { unit_value },
             ref t => return Err(location.new_unexpected_token_error(t.clone())),

--- a/color/lib.rs
+++ b/color/lib.rs
@@ -706,27 +706,6 @@ macro_rules! impl_lab_like {
             }
         }
 
-        #[cfg(feature = "serde")]
-        impl Serialize for $cls {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: Serializer,
-            {
-                (self.lightness, self.a, self.b, self.alpha).serialize(serializer)
-            }
-        }
-
-        #[cfg(feature = "serde")]
-        impl<'de> Deserialize<'de> for $cls {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                let (lightness, a, b, alpha) = Deserialize::deserialize(deserializer)?;
-                Ok(Self::new(lightness, a, b, alpha))
-            }
-        }
-
         impl ToCss for $cls {
             fn to_css<W>(&self, dest: &mut W) -> fmt::Result
             where
@@ -796,27 +775,6 @@ macro_rules! impl_lch_like {
                     hue,
                     alpha,
                 }
-            }
-        }
-
-        #[cfg(feature = "serde")]
-        impl Serialize for $cls {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: Serializer,
-            {
-                (self.lightness, self.chroma, self.hue, self.alpha).serialize(serializer)
-            }
-        }
-
-        #[cfg(feature = "serde")]
-        impl<'de> Deserialize<'de> for $cls {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                let (lightness, chroma, hue, alpha) = Deserialize::deserialize(deserializer)?;
-                Ok(Self::new(lightness, chroma, hue, alpha))
             }
         }
 

--- a/color/lib.rs
+++ b/color/lib.rs
@@ -16,8 +16,6 @@ use cssparser::color::{
     PredefinedColorSpace, OPAQUE,
 };
 use cssparser::{match_ignore_ascii_case, CowRcStr, ParseError, Parser, ToCss, Token};
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::f32::consts::PI;
 use std::fmt;
 use std::str::FromStr;
@@ -55,10 +53,8 @@ where
     let token = input.next()?;
     match *token {
         Token::Hash(ref value) | Token::IDHash(ref value) => {
-            parse_hash_color(value.as_bytes()).map(|(r, g, b, a)| {
-                P::Output::from_rgba(r, g, b, a)
-            })
-        },
+            parse_hash_color(value.as_bytes()).map(|(r, g, b, a)| P::Output::from_rgba(r, g, b, a))
+        }
         Token::Ident(ref value) => parse_color_keyword(value),
         Token::Function(ref name) => {
             let name = name.clone();
@@ -506,6 +502,7 @@ fn normalize_hue(hue: f32) -> f32 {
 }
 
 /// A color with red, green, blue, and alpha components, in a byte each.
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct RgbaLegacy {
     /// The red component.
@@ -544,27 +541,6 @@ impl RgbaLegacy {
     }
 }
 
-#[cfg(feature = "serde")]
-impl Serialize for RgbaLegacy {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        (self.red, self.green, self.blue, self.alpha).serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for RgbaLegacy {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let (r, g, b, a) = Deserialize::deserialize(deserializer)?;
-        Ok(RgbaLegacy::new(r, g, b, a))
-    }
-}
-
 impl ToCss for RgbaLegacy {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result
     where
@@ -588,6 +564,7 @@ impl ToCss for RgbaLegacy {
 
 /// Color specified by hue, saturation and lightness components.
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Hsl {
     /// The hue component.
     pub hue: Option<f32>,
@@ -632,29 +609,9 @@ impl ToCss for Hsl {
     }
 }
 
-#[cfg(feature = "serde")]
-impl Serialize for Hsl {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        (self.hue, self.saturation, self.lightness, self.alpha).serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for Hsl {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let (lightness, a, b, alpha) = Deserialize::deserialize(deserializer)?;
-        Ok(Self::new(lightness, a, b, alpha))
-    }
-}
-
 /// Color specified by hue, whiteness and blackness components.
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Hwb {
     /// The hue component.
     pub hue: Option<f32>,
@@ -699,32 +656,12 @@ impl ToCss for Hwb {
     }
 }
 
-#[cfg(feature = "serde")]
-impl Serialize for Hwb {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        (self.hue, self.whiteness, self.blackness, self.alpha).serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for Hwb {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let (lightness, whiteness, blackness, alpha) = Deserialize::deserialize(deserializer)?;
-        Ok(Self::new(lightness, whiteness, blackness, alpha))
-    }
-}
-
 // NOTE: LAB and OKLAB is not declared inside the [impl_lab_like] macro,
 // because it causes cbindgen to ignore them.
 
 /// Color specified by lightness, a- and b-axis components.
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Lab {
     /// The lightness component.
     pub lightness: Option<f32>,
@@ -738,6 +675,7 @@ pub struct Lab {
 
 /// Color specified by lightness, a- and b-axis components.
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Oklab {
     /// The lightness component.
     pub lightness: Option<f32>,
@@ -816,6 +754,7 @@ impl_lab_like!(Oklab, "oklab");
 
 /// Color specified by lightness, chroma and hue components.
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Lch {
     /// The lightness component.
     pub lightness: Option<f32>,
@@ -829,6 +768,7 @@ pub struct Lch {
 
 /// Color specified by lightness, chroma and hue components.
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Oklch {
     /// The lightness component.
     pub lightness: Option<f32>,
@@ -905,6 +845,7 @@ impl_lch_like!(Oklch, "oklch");
 /// A color specified by the color() function.
 /// <https://drafts.csswg.org/css-color-4/#color-function>
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ColorFunction {
     /// The color space for this color.
     pub color_space: PredefinedColorSpace,
@@ -966,6 +907,8 @@ impl ToCss for ColorFunction {
 ///
 /// <https://drafts.csswg.org/css-color-4/#color-type>
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum Color {
     /// The 'currentcolor' keyword.
     CurrentColor,

--- a/color/tests.rs
+++ b/color/tests.rs
@@ -3,25 +3,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use crate::{ColorParser, PredefinedColorSpace, Color, RgbaLegacy};
+use crate::{Color, ColorParser, PredefinedColorSpace, RgbaLegacy};
 use cssparser::{Parser, ParserInput};
 use serde_json::{self, json, Value};
 
 fn almost_equals(a: &Value, b: &Value) -> bool {
     match (a, b) {
-        (&Value::Number(ref a), &Value::Number(ref b)) => {
+        (Value::Number(a), Value::Number(b)) => {
             let a = a.as_f64().unwrap();
             let b = b.as_f64().unwrap();
             (a - b).abs() <= a.abs() * 1e-6
         }
 
         (&Value::Bool(a), &Value::Bool(b)) => a == b,
-        (&Value::String(ref a), &Value::String(ref b)) => a == b,
-        (&Value::Array(ref a), &Value::Array(ref b)) => {
-            a.len() == b.len()
-                && a.iter()
-                    .zip(b.iter())
-                    .all(|(ref a, ref b)| almost_equals(*a, *b))
+        (Value::String(a), Value::String(b)) => a == b,
+        (Value::Array(a), Value::Array(b)) => {
+            a.len() == b.len() && a.iter().zip(b.iter()).all(|(a, b)| almost_equals(a, b))
         }
         (&Value::Object(_), &Value::Object(_)) => panic!("Not implemented"),
         (&Value::Null, &Value::Null) => true,
@@ -43,8 +40,7 @@ fn assert_json_eq(results: Value, expected: Value, message: &str) {
     }
 }
 
-
-fn run_raw_json_tests<F: Fn(Value, Value) -> ()>(json_data: &str, run: F) {
+fn run_raw_json_tests<F: Fn(Value, Value)>(json_data: &str, run: F) {
     let items = match serde_json::from_str(json_data) {
         Ok(Value::Array(items)) => items,
         other => panic!("Invalid JSON: {:?}", other),
@@ -92,11 +88,14 @@ fn color3() {
 #[cfg_attr(all(miri, feature = "skip_long_tests"), ignore)]
 #[test]
 fn color3_hsl() {
-    run_color_tests(include_str!("../src/css-parsing-tests/color3_hsl.json"), |c| {
-        c.ok()
-            .map(|v| v.to_css_string().to_json())
-            .unwrap_or(Value::Null)
-    })
+    run_color_tests(
+        include_str!("../src/css-parsing-tests/color3_hsl.json"),
+        |c| {
+            c.ok()
+                .map(|v| v.to_css_string().to_json())
+                .unwrap_or(Value::Null)
+        },
+    )
 }
 
 /// color3_keywords.json is different: R, G and B are in 0..255 rather than 0..1
@@ -115,11 +114,14 @@ fn color3_keywords() {
 #[cfg_attr(all(miri, feature = "skip_long_tests"), ignore)]
 #[test]
 fn color4_hwb() {
-    run_color_tests(include_str!("../src/css-parsing-tests/color4_hwb.json"), |c| {
-        c.ok()
-            .map(|v| v.to_css_string().to_json())
-            .unwrap_or(Value::Null)
-    })
+    run_color_tests(
+        include_str!("../src/css-parsing-tests/color4_hwb.json"),
+        |c| {
+            c.ok()
+                .map(|v| v.to_css_string().to_json())
+                .unwrap_or(Value::Null)
+        },
+    )
 }
 
 #[cfg_attr(all(miri, feature = "skip_long_tests"), ignore)]
@@ -355,7 +357,7 @@ fn generic_parser() {
     ];
 
     for (input, expected) in TESTS {
-        let mut input = ParserInput::new(*input);
+        let mut input = ParserInput::new(input);
         let mut input = Parser::new(&mut input);
 
         let actual: OutputType = parse_color_with(&TestColorParser, &mut input).unwrap();

--- a/color/tests.rs
+++ b/color/tests.rs
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::*;
-use crate::{Color, ColorParser, PredefinedColorSpace, RgbaLegacy};
-use cssparser::{Parser, ParserInput};
-use serde_json::{self, json, Value};
+use cssparser::ParserInput;
+use serde_json::{json, Value};
 
 fn almost_equals(a: &Value, b: &Value) -> bool {
     match (a, b) {

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -48,9 +48,7 @@ fn get_byte_from_lit(lit: &syn::Lit) -> u8 {
 
 fn get_byte_from_expr_lit(expr: &syn::Expr) -> u8 {
     match *expr {
-        syn::Expr::Lit(syn::ExprLit { ref lit, .. }) => {
-            get_byte_from_lit(lit)
-        }
+        syn::Expr::Lit(syn::ExprLit { ref lit, .. }) => get_byte_from_lit(lit),
         _ => unreachable!(),
     }
 }
@@ -63,15 +61,17 @@ fn parse_pat_to_table<'a>(
     table: &mut [u8; 256],
 ) {
     match pat {
-        &syn::Pat::Lit(syn::PatLit { ref lit, .. }) => {
+        syn::Pat::Lit(syn::PatLit { ref lit, .. }) => {
             let value = get_byte_from_lit(lit);
             if table[value as usize] == 0 {
                 table[value as usize] = case_id;
             }
         }
-        &syn::Pat::Range(syn::PatRange { ref start, ref end, .. }) => {
-            let lo = get_byte_from_expr_lit(&start.as_ref().unwrap());
-            let hi = get_byte_from_expr_lit(&end.as_ref().unwrap());
+        syn::Pat::Range(syn::PatRange {
+            ref start, ref end, ..
+        }) => {
+            let lo = get_byte_from_expr_lit(start.as_ref().unwrap());
+            let hi = get_byte_from_expr_lit(end.as_ref().unwrap());
             for value in lo..hi {
                 if table[value as usize] == 0 {
                     table[value as usize] = case_id;
@@ -81,14 +81,14 @@ fn parse_pat_to_table<'a>(
                 table[hi as usize] = case_id;
             }
         }
-        &syn::Pat::Wild(_) => {
+        syn::Pat::Wild(_) => {
             for byte in table.iter_mut() {
                 if *byte == 0 {
                     *byte = case_id;
                 }
             }
         }
-        &syn::Pat::Ident(syn::PatIdent { ref ident, .. }) => {
+        syn::Pat::Ident(syn::PatIdent { ref ident, .. }) => {
             assert_eq!(*wildcard, None);
             *wildcard = Some(ident);
             for byte in table.iter_mut() {
@@ -97,7 +97,7 @@ fn parse_pat_to_table<'a>(
                 }
             }
         }
-        &syn::Pat::Or(syn::PatOr { ref cases, .. }) => {
+        syn::Pat::Or(syn::PatOr { ref cases, .. }) => {
             for case in cases {
                 parse_pat_to_table(case, case_id, wildcard, table);
             }

--- a/src/color.rs
+++ b/src/color.rs
@@ -77,6 +77,8 @@ pub fn serialize_color_alpha(
 /// A Predefined color space specified in:
 /// <https://drafts.csswg.org/css-color-4/#predefined>
 #[derive(Clone, Copy, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum PredefinedColorSpace {
     /// <https://drafts.csswg.org/css-color-4/#predefined-sRGB>
     Srgb,

--- a/src/cow_rc_str.rs
+++ b/src/cow_rc_str.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::{Borrow, Cow};
 use std::rc::Rc;
-use std::{cmp, fmt, hash, marker, mem, ops, slice, str, ptr};
+use std::{cmp, fmt, hash, marker, mem, ops, ptr, slice, str};
 
 /// A string that is either shared (heap-allocated and reference-counted) or borrowed.
 ///
@@ -23,9 +23,9 @@ pub struct CowRcStr<'a> {
     phantom: marker::PhantomData<Result<&'a str, Rc<String>>>,
 }
 
-fn _static_assert_same_size<'a>() {
+fn _static_assert_same_size() {
     // "Instantiate" the generic function without calling it.
-    let _ = mem::transmute::<CowRcStr<'a>, Option<CowRcStr<'a>>>;
+    let _ = mem::transmute::<CowRcStr<'_>, Option<CowRcStr<'_>>>;
 }
 
 impl<'a> From<Cow<'a, str>> for CowRcStr<'a> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -182,7 +182,7 @@ pub fn _cssparser_internal_to_lowercase<'a>(
         let input_bytes =
             unsafe { &*(input.as_bytes() as *const [u8] as *const [MaybeUninit<u8>]) };
 
-        buffer.copy_from_slice(&*input_bytes);
+        buffer.copy_from_slice(input_bytes);
 
         // Same as above re layout, plus these bytes have been initialized:
         let buffer = unsafe { &mut *(buffer as *mut [MaybeUninit<u8>] as *mut [u8]) };
@@ -195,7 +195,7 @@ pub fn _cssparser_internal_to_lowercase<'a>(
     }
 
     Some(
-        match input.bytes().position(|byte| matches!(byte, b'A'..=b'Z')) {
+        match input.bytes().position(|byte| byte.is_ascii_uppercase()) {
             Some(first_uppercase) => make_ascii_lowercase(buffer, input, first_uppercase),
             // common case: input is already lower-case
             None => input,

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -9,7 +9,7 @@ use super::{BasicParseError, Parser, ParserInput, Token};
 /// in which case the caller needs to check if the arguments’ parser is exhausted.
 /// Return `Ok((A, B))`, or `Err(())` for a syntax error.
 pub fn parse_nth<'i>(input: &mut Parser<'i, '_>) -> Result<(i32, i32), BasicParseError<'i>> {
-    match *input.next()? {
+    match *input.try_next()? {
         Token::Number {
             int_value: Some(b), ..
         } => Ok((0, b)),
@@ -55,7 +55,7 @@ pub fn parse_nth<'i>(input: &mut Parser<'i, '_>) -> Result<(i32, i32), BasicPars
                 }
             }
         }
-        Token::Delim('+') => match *input.next_including_whitespace()? {
+        Token::Delim('+') => match *input.try_next_including_whitespace()? {
             Token::Ident(ref value) => {
                 match_ignore_ascii_case! { value,
                     "n" => parse_b(input, 1),
@@ -83,7 +83,7 @@ pub fn parse_nth<'i>(input: &mut Parser<'i, '_>) -> Result<(i32, i32), BasicPars
 
 fn parse_b<'i>(input: &mut Parser<'i, '_>, a: i32) -> Result<(i32, i32), BasicParseError<'i>> {
     let start = input.state();
-    match input.next() {
+    match input.try_next() {
         Ok(&Token::Delim('+')) => parse_signless_b(input, a, 1),
         Ok(&Token::Delim('-')) => parse_signless_b(input, a, -1),
         Ok(&Token::Number {
@@ -104,7 +104,7 @@ fn parse_signless_b<'i>(
     b_sign: i32,
 ) -> Result<(i32, i32), BasicParseError<'i>> {
     // FIXME: remove .clone() when lifetimes are non-lexical.
-    match input.next()?.clone() {
+    match input.try_next()?.clone() {
         Token::Number {
             has_sign: false,
             int_value: Some(b),
@@ -132,7 +132,7 @@ fn parse_number_saturate(string: &str) -> Result<i32, ()> {
     let int = if let Ok(&Token::Number {
         int_value: Some(int),
         ..
-    }) = parser.next_including_whitespace_and_comments()
+    }) = parser.try_next_including_whitespace_and_comments()
     {
         int
     } else {

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -8,7 +8,7 @@ use super::{BasicParseError, Parser, ParserInput, Token};
 /// The input is typically the arguments of a function,
 /// in which case the caller needs to check if the arguments’ parser is exhausted.
 /// Return `Ok((A, B))`, or `Err(())` for a syntax error.
-pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), BasicParseError<'i>> {
+pub fn parse_nth<'i>(input: &mut Parser<'i, '_>) -> Result<(i32, i32), BasicParseError<'i>> {
     match *input.next()? {
         Token::Number {
             int_value: Some(b), ..
@@ -22,7 +22,7 @@ pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), Basic
                 unit,
                 "n" => Ok(parse_b(input, a)?),
                 "n-" => Ok(parse_signless_b(input, a, -1)?),
-                _ => match parse_n_dash_digits(&*unit) {
+                _ => match parse_n_dash_digits(unit) {
                     Ok(b) => Ok((a, b)),
                     Err(()) => {
                         let unit = unit.clone();
@@ -40,8 +40,8 @@ pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), Basic
                 "n-" => Ok(parse_signless_b(input, 1, -1)?),
                 "-n-" => Ok(parse_signless_b(input, -1, -1)?),
                 _ => {
-                    let (slice, a) = if value.starts_with("-") {
-                        (&value[1..], -1)
+                    let (slice, a) = if let Some(stripped) = value.strip_prefix('-') {
+                        (stripped, -1)
                     } else {
                         (&**value, 1)
                     };
@@ -81,7 +81,7 @@ pub fn parse_nth<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(i32, i32), Basic
     }
 }
 
-fn parse_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32) -> Result<(i32, i32), BasicParseError<'i>> {
+fn parse_b<'i>(input: &mut Parser<'i, '_>, a: i32) -> Result<(i32, i32), BasicParseError<'i>> {
     let start = input.state();
     match input.next() {
         Ok(&Token::Delim('+')) => parse_signless_b(input, a, 1),
@@ -98,8 +98,8 @@ fn parse_b<'i, 't>(input: &mut Parser<'i, 't>, a: i32) -> Result<(i32, i32), Bas
     }
 }
 
-fn parse_signless_b<'i, 't>(
-    input: &mut Parser<'i, 't>,
+fn parse_signless_b<'i>(
+    input: &mut Parser<'i, '_>,
     a: i32,
     b_sign: i32,
 ) -> Result<(i32, i32), BasicParseError<'i>> {
@@ -118,7 +118,7 @@ fn parse_n_dash_digits(string: &str) -> Result<i32, ()> {
     let bytes = string.as_bytes();
     if bytes.len() >= 3
         && bytes[..2].eq_ignore_ascii_case(b"n-")
-        && bytes[2..].iter().all(|&c| matches!(c, b'0'..=b'9'))
+        && bytes[2..].iter().all(|&c| c.is_ascii_digit())
     {
         Ok(parse_number_saturate(&string[1..]).unwrap()) // Include the minus sign
     } else {

--- a/src/nth.rs
+++ b/src/nth.rs
@@ -9,7 +9,7 @@ use super::{BasicParseError, Parser, ParserInput, Token};
 /// in which case the caller needs to check if the arguments’ parser is exhausted.
 /// Return `Ok((A, B))`, or `Err(())` for a syntax error.
 pub fn parse_nth<'i>(input: &mut Parser<'i, '_>) -> Result<(i32, i32), BasicParseError<'i>> {
-    match *input.try_next()? {
+    match *input.next()? {
         Token::Number {
             int_value: Some(b), ..
         } => Ok((0, b)),
@@ -55,7 +55,7 @@ pub fn parse_nth<'i>(input: &mut Parser<'i, '_>) -> Result<(i32, i32), BasicPars
                 }
             }
         }
-        Token::Delim('+') => match *input.try_next_including_whitespace()? {
+        Token::Delim('+') => match *input.next_including_whitespace()? {
             Token::Ident(ref value) => {
                 match_ignore_ascii_case! { value,
                     "n" => parse_b(input, 1),
@@ -83,7 +83,7 @@ pub fn parse_nth<'i>(input: &mut Parser<'i, '_>) -> Result<(i32, i32), BasicPars
 
 fn parse_b<'i>(input: &mut Parser<'i, '_>, a: i32) -> Result<(i32, i32), BasicParseError<'i>> {
     let start = input.state();
-    match input.try_next() {
+    match input.next() {
         Ok(&Token::Delim('+')) => parse_signless_b(input, a, 1),
         Ok(&Token::Delim('-')) => parse_signless_b(input, a, -1),
         Ok(&Token::Number {
@@ -104,7 +104,7 @@ fn parse_signless_b<'i>(
     b_sign: i32,
 ) -> Result<(i32, i32), BasicParseError<'i>> {
     // FIXME: remove .clone() when lifetimes are non-lexical.
-    match input.try_next()?.clone() {
+    match input.next()?.clone() {
         Token::Number {
             has_sign: false,
             int_value: Some(b),
@@ -132,7 +132,7 @@ fn parse_number_saturate(string: &str) -> Result<i32, ()> {
     let int = if let Ok(&Token::Number {
         int_value: Some(int),
         ..
-    }) = parser.try_next_including_whitespace_and_comments()
+    }) = parser.next_including_whitespace_and_comments()
     {
         int
     } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -834,7 +834,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
     /// expect_ident, but clone the CowRcStr
     #[inline]
     pub fn expect_ident_cloned(&mut self) -> Result<CowRcStr<'i>, BasicParseError<'i>> {
-        self.expect_ident().map(|s| s.clone())
+        self.expect_ident().cloned()
     }
 
     /// Parse a <ident-token> whose unescaped value is an ASCII-insensitive match for the given value.
@@ -859,7 +859,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
     /// expect_string, but clone the CowRcStr
     #[inline]
     pub fn expect_string_cloned(&mut self) -> Result<CowRcStr<'i>, BasicParseError<'i>> {
-        self.expect_string().map(|s| s.clone())
+        self.expect_string().cloned()
     }
 
     /// Parse either a <ident-token> or a <string-token>, and return the unescaped value.
@@ -878,7 +878,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
             Token::UnquotedUrl(ref value) => Ok(value.clone()),
             Token::Function(ref name) if name.eq_ignore_ascii_case("url") => {
                 self.parse_nested_block(|input| {
-                    input.expect_string().map_err(Into::into).map(|s| s.clone())
+                    input.expect_string().map_err(Into::into).cloned()
                 })
                 .map_err(ParseError::<()>::basic)
             }
@@ -893,7 +893,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
             Token::QuotedString(ref value) => Ok(value.clone()),
             Token::Function(ref name) if name.eq_ignore_ascii_case("url") => {
                 self.parse_nested_block(|input| {
-                    input.expect_string().map_err(Into::into).map(|s| s.clone())
+                    input.expect_string().map_err(Into::into).cloned()
                 })
                 .map_err(ParseError::<()>::basic)
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -116,7 +116,7 @@ impl<'i, T> From<BasicParseError<'i>> for ParseError<'i, T> {
 impl SourceLocation {
     /// Create a new BasicParseError at this location for an unexpected token
     #[inline]
-    pub fn new_basic_unexpected_token_error<'i>(self, token: Token<'i>) -> BasicParseError<'i> {
+    pub fn new_basic_unexpected_token_error(self, token: Token<'_>) -> BasicParseError<'_> {
         BasicParseError {
             kind: BasicParseErrorKind::UnexpectedToken(token),
             location: self,
@@ -125,7 +125,7 @@ impl SourceLocation {
 
     /// Create a new ParseError at this location for an unexpected token
     #[inline]
-    pub fn new_unexpected_token_error<'i, E>(self, token: Token<'i>) -> ParseError<'i, E> {
+    pub fn new_unexpected_token_error<E>(self, token: Token<'_>) -> ParseError<'_, E> {
         ParseError {
             kind: ParseErrorKind::Basic(BasicParseErrorKind::UnexpectedToken(token)),
             location: self,
@@ -652,9 +652,8 @@ impl<'i: 't, 't> Parser<'i, 't> {
         let token = if using_cached_token {
             let cached_token = self.input.cached_token.as_ref().unwrap();
             self.input.tokenizer.reset(&cached_token.end_state);
-            match cached_token.token {
-                Token::Function(ref name) => self.input.tokenizer.see_function(name),
-                _ => {}
+            if let Token::Function(ref name) = cached_token.token {
+                self.input.tokenizer.see_function(name)
             }
             &cached_token.token
         } else {
@@ -748,7 +747,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
             match self.parse_until_before(Delimiter::Comma, &mut parse_one) {
                 Ok(v) => values.push(v),
                 Err(e) if !ignore_errors => return Err(e),
-                Err(_) => {},
+                Err(_) => {}
             }
             match self.next() {
                 Err(_) => return Ok(values),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -360,7 +360,7 @@ macro_rules! expect {
     ($parser: ident, $($branches: tt)+) => {
         {
             let start_location = $parser.current_source_location();
-            match *$parser.try_next()? {
+            match *$parser.next()? {
                 $($branches)+
                 ref token => {
                     return Err(start_location.new_basic_unexpected_token_error(token.clone()))
@@ -401,7 +401,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
     #[inline]
     pub fn expect_exhausted(&mut self) -> Result<(), BasicParseError<'i>> {
         let start = self.state();
-        let result = match self.try_next() {
+        let result = match self.next() {
             Err(BasicParseError {
                 kind: BasicParseErrorKind::EndOfInput,
                 ..
@@ -486,7 +486,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
     /// Create a new unexpected token or EOF ParseError at the current location
     #[inline]
     pub fn new_error_for_next_token<E>(&mut self) -> ParseError<'i, E> {
-        let token = match self.try_next() {
+        let token = match self.next() {
             Ok(token) => token.clone(),
             Err(e) => return e.into(),
         };
@@ -606,15 +606,15 @@ impl<'i: 't, 't> Parser<'i, 't> {
     /// See the `Parser::parse_nested_block` method to parse the content of functions or blocks.
     ///
     /// This only returns a closing token when it is unmatched (and therefore an error).
-    pub fn try_next(&mut self) -> Result<&Token<'i>, BasicParseError<'i>> {
+    pub fn next(&mut self) -> Result<&Token<'i>, BasicParseError<'i>> {
         self.skip_whitespace();
-        self.try_next_including_whitespace_and_comments()
+        self.next_including_whitespace_and_comments()
     }
 
     /// Same as `Parser::next`, but does not skip whitespace tokens.
-    pub fn try_next_including_whitespace(&mut self) -> Result<&Token<'i>, BasicParseError<'i>> {
+    pub fn next_including_whitespace(&mut self) -> Result<&Token<'i>, BasicParseError<'i>> {
         loop {
-            match self.try_next_including_whitespace_and_comments() {
+            match self.next_including_whitespace_and_comments() {
                 Err(e) => return Err(e),
                 Ok(&Token::Comment(_)) => {}
                 _ => break,
@@ -629,7 +629,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
     /// where comments are preserved.
     /// When parsing higher-level values, per the CSS Syntax specification,
     /// comments should always be ignored between tokens.
-    pub fn try_next_including_whitespace_and_comments(
+    pub fn next_including_whitespace_and_comments(
         &mut self,
     ) -> Result<&Token<'i>, BasicParseError<'i>> {
         if let Some(block_type) = self.at_start_of.take() {
@@ -749,7 +749,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
                 Err(e) if !ignore_errors => return Err(e),
                 Err(_) => {}
             }
-            match self.try_next() {
+            match self.next() {
                 Err(_) => return Ok(values),
                 Ok(&Token::Comma) => continue,
                 Ok(_) => unreachable!(),
@@ -817,7 +817,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
     #[inline]
     pub fn expect_whitespace(&mut self) -> Result<&'i str, BasicParseError<'i>> {
         let start_location = self.current_source_location();
-        match *self.try_next_including_whitespace()? {
+        match *self.next_including_whitespace()? {
             Token::WhiteSpace(value) => Ok(value),
             ref t => Err(start_location.new_basic_unexpected_token_error(t.clone())),
         }
@@ -1016,7 +1016,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
     #[inline]
     pub fn expect_no_error_token(&mut self) -> Result<(), BasicParseError<'i>> {
         loop {
-            match self.try_next_including_whitespace_and_comments() {
+            match self.next_including_whitespace_and_comments() {
                 Ok(&Token::Function(_))
                 | Ok(&Token::ParenthesisBlock)
                 | Ok(&Token::SquareBracketBlock)

--- a/src/rules_and_declarations.rs
+++ b/src/rules_and_declarations.rs
@@ -14,7 +14,7 @@ use crate::parser::{parse_nested_block, parse_until_after, ParseUntilErrorBehavi
 ///
 /// Typical usage is `input.try_parse(parse_important).is_ok()`
 /// at the end of a `DeclarationParser::parse_value` implementation.
-pub fn parse_important<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), BasicParseError<'i>> {
+pub fn parse_important<'i>(input: &mut Parser<'i, '_>) -> Result<(), BasicParseError<'i>> {
     input.expect_delim('!')?;
     input.expect_ident_matching("important")
 }
@@ -253,10 +253,10 @@ where
             self.input.skip_whitespace();
             let start = self.input.state();
             match self.input.next_including_whitespace_and_comments().ok()? {
-                Token::CloseCurlyBracket |
-                Token::WhiteSpace(..) |
-                Token::Semicolon |
-                Token::Comment(..) => continue,
+                Token::CloseCurlyBracket
+                | Token::WhiteSpace(..)
+                | Token::Semicolon
+                | Token::Comment(..) => continue,
                 Token::AtKeyword(ref name) => {
                     let name = name.clone();
                     return Some(parse_at_rule(&start, name, self.input, &mut *self.parser));
@@ -294,7 +294,7 @@ where
                             &mut *self.parser,
                             Delimiter::Semicolon | Delimiter::CurlyBracketBlock,
                         ) {
-                            return Some(Ok(qual))
+                            return Some(Ok(qual));
                         }
                     }
 
@@ -367,7 +367,7 @@ where
             let start = self.input.state();
             let at_keyword = match self.input.next_byte()? {
                 b'@' => match self.input.next_including_whitespace_and_comments() {
-                    Ok(&Token::AtKeyword(ref name)) => Some(name.clone()),
+                    Ok(Token::AtKeyword(name)) => Some(name.clone()),
                     _ => {
                         self.input.reset(&start);
                         None
@@ -503,5 +503,5 @@ where
     input.expect_curly_bracket_block()?;
     // Do this here so that we consume the `{` even if the prelude is `Err`.
     let prelude = prelude?;
-    parse_nested_block(input, |input| parser.parse_block(prelude, &start, input))
+    parse_nested_block(input, |input| parser.parse_block(prelude, start, input))
 }

--- a/src/rules_and_declarations.rs
+++ b/src/rules_and_declarations.rs
@@ -252,7 +252,11 @@ where
         loop {
             self.input.skip_whitespace();
             let start = self.input.state();
-            match self.input.next_including_whitespace_and_comments().ok()? {
+            match self
+                .input
+                .try_next_including_whitespace_and_comments()
+                .ok()?
+            {
                 Token::CloseCurlyBracket
                 | Token::WhiteSpace(..)
                 | Token::Semicolon
@@ -366,7 +370,7 @@ where
             self.input.skip_cdc_and_cdo();
             let start = self.input.state();
             let at_keyword = match self.input.next_byte()? {
-                b'@' => match self.input.next_including_whitespace_and_comments() {
+                b'@' => match self.input.try_next_including_whitespace_and_comments() {
                     Ok(Token::AtKeyword(name)) => Some(name.clone()),
                     _ => {
                         self.input.reset(&start);
@@ -436,7 +440,7 @@ where
         input.skip_whitespace();
         let start = input.state();
         let at_keyword = if input.next_byte() == Some(b'@') {
-            match *input.next_including_whitespace_and_comments()? {
+            match *input.try_next_including_whitespace_and_comments()? {
                 Token::AtKeyword(ref name) => Some(name.clone()),
                 _ => {
                     input.reset(&start);
@@ -468,7 +472,7 @@ where
     let result = input.parse_until_before(delimiters, |input| parser.parse_prelude(name, input));
     match result {
         Ok(prelude) => {
-            let result = match input.next() {
+            let result = match input.try_next() {
                 Ok(&Token::Semicolon) | Err(_) => parser
                     .rule_without_block(prelude, start)
                     .map_err(|()| input.new_unexpected_token_error(Token::Semicolon)),
@@ -481,7 +485,7 @@ where
         }
         Err(error) => {
             let end_position = input.position();
-            match input.next() {
+            match input.try_next() {
                 Ok(&Token::CurlyBracketBlock) | Ok(&Token::Semicolon) | Err(_) => {}
                 _ => unreachable!(),
             };

--- a/src/rules_and_declarations.rs
+++ b/src/rules_and_declarations.rs
@@ -252,11 +252,7 @@ where
         loop {
             self.input.skip_whitespace();
             let start = self.input.state();
-            match self
-                .input
-                .try_next_including_whitespace_and_comments()
-                .ok()?
-            {
+            match self.input.next_including_whitespace_and_comments().ok()? {
                 Token::CloseCurlyBracket
                 | Token::WhiteSpace(..)
                 | Token::Semicolon
@@ -370,7 +366,7 @@ where
             self.input.skip_cdc_and_cdo();
             let start = self.input.state();
             let at_keyword = match self.input.next_byte()? {
-                b'@' => match self.input.try_next_including_whitespace_and_comments() {
+                b'@' => match self.input.next_including_whitespace_and_comments() {
                     Ok(Token::AtKeyword(name)) => Some(name.clone()),
                     _ => {
                         self.input.reset(&start);
@@ -440,7 +436,7 @@ where
         input.skip_whitespace();
         let start = input.state();
         let at_keyword = if input.next_byte() == Some(b'@') {
-            match *input.try_next_including_whitespace_and_comments()? {
+            match *input.next_including_whitespace_and_comments()? {
                 Token::AtKeyword(ref name) => Some(name.clone()),
                 _ => {
                     input.reset(&start);
@@ -472,7 +468,7 @@ where
     let result = input.parse_until_before(delimiters, |input| parser.parse_prelude(name, input));
     match result {
         Ok(prelude) => {
-            let result = match input.try_next() {
+            let result = match input.next() {
                 Ok(&Token::Semicolon) | Err(_) => parser
                     .rule_without_block(prelude, start)
                     .map_err(|()| input.new_unexpected_token_error(Token::Semicolon)),
@@ -485,7 +481,7 @@ where
         }
         Err(error) => {
             let end_position = input.position();
-            match input.try_next() {
+            match input.next() {
                 Ok(&Token::CurlyBracketBlock) | Ok(&Token::Semicolon) | Err(_) => {}
                 _ => unreachable!(),
             };

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -378,19 +378,110 @@ impl_tocss_for_float!(f32);
 impl_tocss_for_float!(f64);
 
 /// A category of token. See the `needs_separator_when_before` method.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub struct TokenSerializationType(TokenSerializationTypeVariants);
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+pub enum TokenSerializationType {
+    /// No token serialization type.
+    #[default]
+    Nothing,
+
+    /// The [`<whitespace-token>`](https://drafts.csswg.org/css-syntax/#whitespace-token-diagram)
+    /// type.
+    WhiteSpace,
+
+    /// The [`<at-keyword-token>`](https://drafts.csswg.org/css-syntax/#at-keyword-token-diagram)
+    /// type, the "[`<hash-token>`](https://drafts.csswg.org/css-syntax/#hash-token-diagram) with
+    /// the type flag set to 'unrestricted'" type, or the
+    /// "[`<hash-token>`](https://drafts.csswg.org/css-syntax/#hash-token-diagram) with the type
+    /// flag set to 'id'" type.
+    AtKeywordOrHash,
+
+    /// The [`<number-token>`](https://drafts.csswg.org/css-syntax/#number-token-diagram) type.
+    Number,
+
+    /// The [`<dimension-token>`](https://drafts.csswg.org/css-syntax/#dimension-token-diagram)
+    /// type.
+    Dimension,
+
+    /// The [`<percentage-token>`](https://drafts.csswg.org/css-syntax/#percentage-token-diagram)
+    /// type.
+    Percentage,
+
+    /// The [`<url-token>`](https://drafts.csswg.org/css-syntax/#url-token-diagram) or
+    /// `<bad-url-token>` type.
+    UrlOrBadUrl,
+
+    /// The [`<function-token>`](https://drafts.csswg.org/css-syntax/#function-token-diagram) type.
+    Function,
+
+    /// The [`<ident-token>`](https://drafts.csswg.org/css-syntax/#ident-token-diagram) type.
+    Ident,
+
+    /// The `-->` [`<CDC-token>`](https://drafts.csswg.org/css-syntax/#CDC-token-diagram) type.
+    CDC,
+
+    /// The `|=`
+    /// [`<dash-match-token>`](https://drafts.csswg.org/css-syntax/#dash-match-token-diagram) type.
+    DashMatch,
+
+    /// The `*=`
+    /// [`<substring-match-token>`](https://drafts.csswg.org/css-syntax/#substring-match-token-diagram)
+    /// type.
+    SubstringMatch,
+
+    /// The `<(-token>` type.
+    OpenParen,
+
+    /// The `#` `<delim-token>` type.
+    DelimHash,
+
+    /// The `@` `<delim-token>` type.
+    DelimAt,
+
+    /// The `.` or `+` `<delim-token>` type.
+    DelimDotOrPlus,
+
+    /// The `-` `<delim-token>` type.
+    DelimMinus,
+
+    /// The `?` `<delim-token>` type.
+    DelimQuestion,
+
+    /// The `$`, `^`, or `~` `<delim-token>` type.
+    DelimAssorted,
+
+    /// The `=` `<delim-token>` type.
+    DelimEquals,
+
+    /// The `|` `<delim-token>` type.
+    DelimBar,
+
+    /// The `/` `<delim-token>` type.
+    DelimSlash,
+
+    /// The `*` `<delim-token>` type.
+    DelimAsterisk,
+
+    /// The `%` `<delim-token>` type.
+    DelimPercent,
+
+    /// A type indicating any other token.
+    Other,
+}
 
 impl TokenSerializationType {
     /// Return a value that represents the absence of a token, e.g. before the start of the input.
+    #[deprecated(
+        since = "0.32.1",
+        note = "use TokenSerializationType::Nothing or TokenSerializationType::default() instead"
+    )]
     pub fn nothing() -> TokenSerializationType {
-        TokenSerializationType(TokenSerializationTypeVariants::Nothing)
+        Default::default()
     }
 
-    /// If this value is `TokenSerializationType::nothing()`, set it to the given value instead.
+    /// If this value is `TokenSerializationType::Nothing`, set it to the given value instead.
     pub fn set_if_nothing(&mut self, new_value: TokenSerializationType) {
-        if self.0 == TokenSerializationTypeVariants::Nothing {
-            self.0 = new_value.0
+        if matches!(self, TokenSerializationType::Nothing) {
+            *self = new_value
         }
     }
 
@@ -404,10 +495,10 @@ impl TokenSerializationType {
     /// See https://github.com/w3c/csswg-drafts/issues/4088 for the
     /// `DelimPercent` bits.
     pub fn needs_separator_when_before(self, other: TokenSerializationType) -> bool {
-        use self::TokenSerializationTypeVariants::*;
-        match self.0 {
+        use self::TokenSerializationType::*;
+        match self {
             Ident => matches!(
-                other.0,
+                other,
                 Ident
                     | Function
                     | UrlOrBadUrl
@@ -419,15 +510,15 @@ impl TokenSerializationType {
                     | OpenParen
             ),
             AtKeywordOrHash | Dimension => matches!(
-                other.0,
+                other,
                 Ident | Function | UrlOrBadUrl | DelimMinus | Number | Percentage | Dimension | CDC
             ),
             DelimHash | DelimMinus => matches!(
-                other.0,
+                other,
                 Ident | Function | UrlOrBadUrl | DelimMinus | Number | Percentage | Dimension
             ),
             Number => matches!(
-                other.0,
+                other,
                 Ident
                     | Function
                     | UrlOrBadUrl
@@ -437,11 +528,11 @@ impl TokenSerializationType {
                     | DelimPercent
                     | Dimension
             ),
-            DelimAt => matches!(other.0, Ident | Function | UrlOrBadUrl | DelimMinus),
-            DelimDotOrPlus => matches!(other.0, Number | Percentage | Dimension),
-            DelimAssorted | DelimAsterisk => matches!(other.0, DelimEquals),
-            DelimBar => matches!(other.0, DelimEquals | DelimBar | DashMatch),
-            DelimSlash => matches!(other.0, DelimAsterisk | SubstringMatch),
+            DelimAt => matches!(other, Ident | Function | UrlOrBadUrl | DelimMinus),
+            DelimDotOrPlus => matches!(other, Number | Percentage | Dimension),
+            DelimAssorted | DelimAsterisk => matches!(other, DelimEquals),
+            DelimBar => matches!(other, DelimEquals | DelimBar | DashMatch),
+            DelimSlash => matches!(other, DelimAsterisk | SubstringMatch),
             Nothing | WhiteSpace | Percentage | UrlOrBadUrl | Function | CDC | OpenParen
             | DashMatch | SubstringMatch | DelimQuestion | DelimEquals | DelimPercent | Other => {
                 false
@@ -450,43 +541,14 @@ impl TokenSerializationType {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-enum TokenSerializationTypeVariants {
-    Nothing,
-    WhiteSpace,
-    AtKeywordOrHash,
-    Number,
-    Dimension,
-    Percentage,
-    UrlOrBadUrl,
-    Function,
-    Ident,
-    CDC,
-    DashMatch,
-    SubstringMatch,
-    OpenParen,      // '('
-    DelimHash,      // '#'
-    DelimAt,        // '@'
-    DelimDotOrPlus, // '.', '+'
-    DelimMinus,     // '-'
-    DelimQuestion,  // '?'
-    DelimAssorted,  // '$', '^', '~'
-    DelimEquals,    // '='
-    DelimBar,       // '|'
-    DelimSlash,     // '/'
-    DelimAsterisk,  // '*'
-    DelimPercent,   // '%'
-    Other,          // anything else
-}
-
 impl<'a> Token<'a> {
     /// Categorize a token into a type that determines when `/**/` needs to be inserted
     /// between two tokens when serialized next to each other without whitespace in between.
     ///
     /// See the `TokenSerializationType::needs_separator_when_before` method.
     pub fn serialization_type(&self) -> TokenSerializationType {
-        use self::TokenSerializationTypeVariants::*;
-        TokenSerializationType(match *self {
+        use self::TokenSerializationType::*;
+        match self {
             Token::Ident(_) => Ident,
             Token::AtKeyword(_) | Token::Hash(_) | Token::IDHash(_) => AtKeywordOrHash,
             Token::UnquotedUrl(_) | Token::BadUrl(_) => UrlOrBadUrl,
@@ -526,6 +588,6 @@ impl<'a> Token<'a> {
             | Token::IncludeMatch
             | Token::PrefixMatch
             | Token::SuffixMatch => Other,
-        })
+        }
     }
 }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::match_byte;
-use dtoa_short::{self, Notation};
+use dtoa_short::Notation;
 use std::fmt::{self, Write};
 use std::str;
 

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -4,7 +4,6 @@
 
 use crate::match_byte;
 use dtoa_short::{self, Notation};
-use itoa;
 use std::fmt::{self, Write};
 use std::str;
 
@@ -49,10 +48,9 @@ where
         dtoa_short::write(dest, value)?
     };
 
-    if int_value.is_none() && value.fract() == 0. {
-        if !notation.decimal_point && !notation.scientific {
-            dest.write_str(".0")?;
-        }
+    if int_value.is_none() && value.fract() == 0. && !notation.decimal_point && !notation.scientific
+    {
+        dest.write_str(".0")?;
     }
     Ok(())
 }
@@ -63,10 +61,10 @@ impl<'a> ToCss for Token<'a> {
         W: fmt::Write,
     {
         match *self {
-            Token::Ident(ref value) => serialize_identifier(&**value, dest)?,
+            Token::Ident(ref value) => serialize_identifier(value, dest)?,
             Token::AtKeyword(ref value) => {
                 dest.write_str("@")?;
-                serialize_identifier(&**value, dest)?;
+                serialize_identifier(value, dest)?;
             }
             Token::Hash(ref value) => {
                 dest.write_str("#")?;
@@ -74,12 +72,12 @@ impl<'a> ToCss for Token<'a> {
             }
             Token::IDHash(ref value) => {
                 dest.write_str("#")?;
-                serialize_identifier(&**value, dest)?;
+                serialize_identifier(value, dest)?;
             }
-            Token::QuotedString(ref value) => serialize_string(&**value, dest)?,
+            Token::QuotedString(ref value) => serialize_string(value, dest)?,
             Token::UnquotedUrl(ref value) => {
                 dest.write_str("url(")?;
-                serialize_unquoted_url(&**value, dest)?;
+                serialize_unquoted_url(value, dest)?;
                 dest.write_str(")")?;
             }
             Token::Delim(value) => dest.write_char(value)?,
@@ -134,7 +132,7 @@ impl<'a> ToCss for Token<'a> {
             Token::CDC => dest.write_str("-->")?,
 
             Token::Function(ref name) => {
-                serialize_identifier(&**name, dest)?;
+                serialize_identifier(name, dest)?;
                 dest.write_str("(")?;
             }
             Token::ParenthesisBlock => dest.write_str("(")?,
@@ -167,7 +165,7 @@ fn hex_escape<W>(ascii_byte: u8, dest: &mut W) -> fmt::Result
 where
     W: fmt::Write,
 {
-    static HEX_DIGITS: &'static [u8; 16] = b"0123456789abcdef";
+    static HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
     let b3;
     let b4;
     let bytes = if ascii_byte > 0x0F {
@@ -179,7 +177,7 @@ where
         b3 = [b'\\', HEX_DIGITS[ascii_byte as usize], b' '];
         &b3[..]
     };
-    dest.write_str(unsafe { str::from_utf8_unchecked(&bytes) })
+    dest.write_str(unsafe { str::from_utf8_unchecked(bytes) })
 }
 
 fn char_escape<W>(ascii_byte: u8, dest: &mut W) -> fmt::Result
@@ -199,9 +197,9 @@ where
         return Ok(());
     }
 
-    if value.starts_with("--") {
+    if let Some(value) = value.strip_prefix("--") {
         dest.write_str("--")?;
-        serialize_name(&value[2..], dest)
+        serialize_name(value, dest)
     } else if value == "-" {
         dest.write_str("\\-")
     } else {
@@ -240,7 +238,7 @@ where
         dest.write_str(&value[chunk_start..i])?;
         if let Some(escaped) = escaped {
             dest.write_str(escaped)?;
-        } else if (b >= b'\x01' && b <= b'\x1F') || b == b'\x7F' {
+        } else if (b'\x01'..=b'\x1F').contains(&b) || b == b'\x7F' {
             hex_escape(b, dest)?;
         } else {
             char_escape(b, dest)?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -466,7 +466,7 @@ fn serializer(preserve_comments: bool) {
             }
             let mut serialized = String::new();
             write_to(
-                TokenSerializationType::nothing(),
+                TokenSerializationType::Nothing,
                 input,
                 &mut serialized,
                 preserve_comments,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -823,7 +823,7 @@ fn numeric(b: &mut Bencher) {
         for _ in 0..1000000 {
             let mut input = ParserInput::new("10px");
             let mut input = Parser::new(&mut input);
-            let _ = test::black_box(input.try_next());
+            let _ = test::black_box(input.next());
         }
     })
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,7 +5,6 @@
 #[cfg(feature = "bench")]
 extern crate test;
 
-use encoding_rs;
 use serde_json::{self, json, Map, Value};
 
 #[cfg(feature = "bench")]
@@ -25,25 +24,23 @@ macro_rules! JArray {
 }
 
 fn almost_equals(a: &Value, b: &Value) -> bool {
-    match (a, b) {
-        (&Value::Number(ref a), &Value::Number(ref b)) => {
+    let var_name = match (a, b) {
+        (Value::Number(a), Value::Number(b)) => {
             let a = a.as_f64().unwrap();
             let b = b.as_f64().unwrap();
             (a - b).abs() <= a.abs() * 1e-6
         }
 
         (&Value::Bool(a), &Value::Bool(b)) => a == b,
-        (&Value::String(ref a), &Value::String(ref b)) => a == b,
-        (&Value::Array(ref a), &Value::Array(ref b)) => {
-            a.len() == b.len()
-                && a.iter()
-                    .zip(b.iter())
-                    .all(|(ref a, ref b)| almost_equals(*a, *b))
+        (Value::String(a), Value::String(b)) => a == b,
+        (Value::Array(a), Value::Array(b)) => {
+            a.len() == b.len() && a.iter().zip(b.iter()).all(|(a, b)| almost_equals(a, b))
         }
         (&Value::Object(_), &Value::Object(_)) => panic!("Not implemented"),
         (&Value::Null, &Value::Null) => true,
         _ => false,
-    }
+    };
+    var_name
 }
 
 fn normalize(json: &mut Value) {
@@ -77,7 +74,7 @@ fn assert_json_eq(results: Value, mut expected: Value, message: &str) {
     }
 }
 
-fn run_raw_json_tests<F: Fn(Value, Value) -> ()>(json_data: &str, run: F) {
+fn run_raw_json_tests<F: Fn(Value, Value)>(json_data: &str, run: F) {
     let items = match serde_json::from_str(json_data) {
         Ok(Value::Array(items)) => items,
         other => panic!("Invalid JSON: {:?}", other),
@@ -242,7 +239,7 @@ fn stylesheet_from_bytes() {
 
     fn get_string<'a>(map: &'a Map<String, Value>, key: &str) -> Option<&'a str> {
         match map.get(key) {
-            Some(&Value::String(ref s)) => Some(s),
+            Some(Value::String(s)) => Some(s),
             Some(&Value::Null) => None,
             None => None,
             _ => panic!("Unexpected JSON"),
@@ -393,7 +390,7 @@ fn unicode_range() {
             if input.is_exhausted() {
                 Ok(result)
             } else {
-                while let Ok(_) = input.next() {}
+                while input.next().is_ok() {}
                 Ok(None)
             }
         });
@@ -593,8 +590,6 @@ fn line_numbers() {
 
 #[test]
 fn overflow() {
-    use std::iter::repeat;
-
     let css = r"
          2147483646
          2147483647
@@ -619,7 +614,7 @@ fn overflow() {
          -3.402824e+38
 
     "
-    .replace("{309 zeros}", &repeat('0').take(309).collect::<String>());
+    .replace("{309 zeros}", &"0".repeat(309));
     let mut input = ParserInput::new(&css);
     let mut input = Parser::new(&mut input);
 
@@ -637,15 +632,13 @@ fn overflow() {
     assert_eq!(input.expect_integer(), Ok(-2147483648));
     assert_eq!(input.expect_integer(), Ok(-2147483648));
 
-    assert_eq!(input.expect_number(), Ok(3.30282347e+38));
+    assert_eq!(input.expect_number(), Ok(3.302_823_5e38));
     assert_eq!(input.expect_number(), Ok(f32::MAX));
     assert_eq!(input.expect_number(), Ok(f32::INFINITY));
-    assert!(f32::MAX != f32::INFINITY);
 
-    assert_eq!(input.expect_number(), Ok(-3.30282347e+38));
+    assert_eq!(input.expect_number(), Ok(-3.302_823_5e38));
     assert_eq!(input.expect_number(), Ok(f32::MIN));
     assert_eq!(input.expect_number(), Ok(f32::NEG_INFINITY));
-    assert!(f32::MIN != f32::NEG_INFINITY);
 }
 
 #[test]
@@ -784,7 +777,7 @@ where
 
 impl<'a> ToJson for CowRcStr<'a> {
     fn to_json(&self) -> Value {
-        let s: &str = &*self;
+        let s: &str = self;
         s.to_json()
     }
 }
@@ -847,7 +840,7 @@ fn no_stack_overflow_multiple_nested_blocks() {
     }
     let mut input = ParserInput::new(&input);
     let mut input = Parser::new(&mut input);
-    while let Ok(..) = input.next() {}
+    while input.next().is_ok() {}
 }
 
 impl<'i> DeclarationParser<'i> for JsonParser {
@@ -870,11 +863,9 @@ impl<'i> DeclarationParser<'i> for JsonParser {
                 // (even CSS Variables forbid top-level `!`)
                 if token == Token::Delim('!') {
                     input.reset(&start);
-                    if parse_important(input).is_ok() {
-                        if input.is_exhausted() {
-                            important = true;
-                            break;
-                        }
+                    if parse_important(input).is_ok() && input.is_exhausted() {
+                        important = true;
+                        break;
                     }
                     input.reset(&start);
                     token = input.next_including_whitespace().unwrap().clone();
@@ -905,7 +896,7 @@ impl<'i> AtRuleParser<'i> for JsonParser {
         ];
         match_ignore_ascii_case! { &*name,
             "charset" => {
-                Err(input.new_error(BasicParseErrorKind::AtRuleInvalid(name.clone()).into()))
+                Err(input.new_error(BasicParseErrorKind::AtRuleInvalid(name.clone())))
             },
             _ => Ok(prelude),
         }
@@ -978,9 +969,9 @@ fn one_component_value_to_json(token: Token, input: &mut Parser) -> Value {
     fn numeric(value: f32, int_value: Option<i32>, has_sign: bool) -> Vec<Value> {
         vec![
             Token::Number {
-                value: value,
-                int_value: int_value,
-                has_sign: has_sign,
+                value,
+                int_value,
+                has_sign,
             }
             .to_css_string()
             .to_json(),
@@ -1137,7 +1128,7 @@ fn parse_until_before_stops_at_delimiter_or_end_of_input() {
                             let ox = ix.next();
                             let oy = iy.next();
                             assert_eq!(ox, oy);
-                            if let Err(_) = ox {
+                            if ox.is_err() {
                                 break;
                             }
                         }
@@ -1223,7 +1214,7 @@ fn parse_sourcemapping_comments() {
     for test in tests {
         let mut input = ParserInput::new(test.0);
         let mut parser = Parser::new(&mut input);
-        while let Ok(_) = parser.next_including_whitespace() {}
+        while parser.next_including_whitespace().is_ok() {}
         assert_eq!(parser.current_source_map_url(), test.1);
     }
 }
@@ -1247,7 +1238,7 @@ fn parse_sourceurl_comments() {
     for test in tests {
         let mut input = ParserInput::new(test.0);
         let mut parser = Parser::new(&mut input);
-        while let Ok(_) = parser.next_including_whitespace() {}
+        while parser.next_including_whitespace().is_ok() {}
         assert_eq!(parser.current_source_url(), test.1);
     }
 }
@@ -1321,7 +1312,8 @@ fn utf16_columns() {
                     break;
                 }
                 Err(_) => {
-                    assert!(false);
+                    // should this be an explicit panic instead?
+                    unreachable!();
                 }
                 Ok(_) => {}
             };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -826,7 +826,7 @@ fn numeric(b: &mut Bencher) {
         for _ in 0..1000000 {
             let mut input = ParserInput::new("10px");
             let mut input = Parser::new(&mut input);
-            let _ = test::black_box(input.next());
+            let _ = test::black_box(input.try_next());
         }
     })
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "bench")]
 extern crate test;
 
-use serde_json::{self, json, Map, Value};
+use serde_json::{json, Map, Value};
 
 #[cfg(feature = "bench")]
 use self::test::Bencher;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -117,10 +117,7 @@ fn one_component_value() {
         include_str!("css-parsing-tests/one_component_value.json"),
         |input| {
             let result: Result<Value, ParseError<()>> = input.parse_entirely(|input| {
-                Ok(one_component_value_to_json(
-                    input.try_next()?.clone(),
-                    input,
-                ))
+                Ok(one_component_value_to_json(input.next()?.clone(), input))
             });
             result.unwrap_or(JArray!["error", "invalid"])
         },
@@ -282,7 +279,7 @@ fn outer_block_end_consumed() {
             .map_err(Into::<ParseError<()>>::into))
         .is_ok());
     println!("{:?}", input.position());
-    assert!(input.try_next().is_err());
+    assert!(input.next().is_err());
 }
 
 /// https://github.com/servo/rust-cssparser/issues/174
@@ -290,7 +287,7 @@ fn outer_block_end_consumed() {
 fn bad_url_slice_out_of_bounds() {
     let mut input = ParserInput::new("url(\u{1}\\");
     let mut parser = Parser::new(&mut input);
-    let result = parser.try_next_including_whitespace_and_comments(); // This used to panic
+    let result = parser.next_including_whitespace_and_comments(); // This used to panic
     assert_eq!(result, Ok(&Token::BadUrl("\u{1}\\".into())));
 }
 
@@ -299,7 +296,7 @@ fn bad_url_slice_out_of_bounds() {
 fn bad_url_slice_not_at_char_boundary() {
     let mut input = ParserInput::new("url(9\n۰");
     let mut parser = Parser::new(&mut input);
-    let result = parser.try_next_including_whitespace_and_comments(); // This used to panic
+    let result = parser.next_including_whitespace_and_comments(); // This used to panic
     assert_eq!(result, Ok(&Token::BadUrl("9\n۰".into())));
 }
 
@@ -327,7 +324,7 @@ fn unquoted_url_escaping() {
          "
     );
     let mut input = ParserInput::new(&serialized);
-    assert_eq!(Parser::new(&mut input).try_next(), Ok(&token));
+    assert_eq!(Parser::new(&mut input).next(), Ok(&token));
 }
 
 #[test]
@@ -393,7 +390,7 @@ fn unicode_range() {
             if input.is_exhausted() {
                 Ok(result)
             } else {
-                while input.try_next().is_ok() {}
+                while input.next().is_ok() {}
                 Ok(None)
             }
         });
@@ -434,10 +431,10 @@ fn serializer(preserve_comments: bool) {
             ) {
                 while let Ok(token) = if preserve_comments {
                     input
-                        .try_next_including_whitespace_and_comments()
+                        .next_including_whitespace_and_comments()
                         .map(|t| t.clone())
                 } else {
-                    input.try_next_including_whitespace().map(|t| t.clone())
+                    input.next_including_whitespace().map(|t| t.clone())
                 } {
                     let token_type = token.serialization_type();
                     if !preserve_comments && previous_token.needs_separator_when_before(token_type)
@@ -483,19 +480,19 @@ fn serialize_bad_tokens() {
     let mut input = ParserInput::new("url(foo\\) b\\)ar)'ba\\'\"z\n4");
     let mut parser = Parser::new(&mut input);
 
-    let token = parser.try_next().unwrap().clone();
+    let token = parser.next().unwrap().clone();
     assert!(matches!(token, Token::BadUrl(_)));
     assert_eq!(token.to_css_string(), "url(foo\\) b\\)ar)");
 
-    let token = parser.try_next().unwrap().clone();
+    let token = parser.next().unwrap().clone();
     assert!(matches!(token, Token::BadString(_)));
     assert_eq!(token.to_css_string(), "\"ba'\\\"z");
 
-    let token = parser.try_next().unwrap().clone();
+    let token = parser.next().unwrap().clone();
     assert!(matches!(token, Token::Number { .. }));
     assert_eq!(token.to_css_string(), "4");
 
-    assert!(parser.try_next().is_err());
+    assert!(parser.next().is_err());
 }
 
 #[test]
@@ -516,7 +513,7 @@ fn line_numbers() {
         SourceLocation { line: 0, column: 1 }
     );
     assert_eq!(
-        input.try_next_including_whitespace(),
+        input.next_including_whitespace(),
         Ok(&Token::Ident("fo00o".into()))
     );
     assert_eq!(
@@ -524,7 +521,7 @@ fn line_numbers() {
         SourceLocation { line: 1, column: 3 }
     );
     assert_eq!(
-        input.try_next_including_whitespace(),
+        input.next_including_whitespace(),
         Ok(&Token::WhiteSpace(" "))
     );
     assert_eq!(
@@ -532,7 +529,7 @@ fn line_numbers() {
         SourceLocation { line: 1, column: 4 }
     );
     assert_eq!(
-        input.try_next_including_whitespace(),
+        input.next_including_whitespace(),
         Ok(&Token::Ident("bar".into()))
     );
     assert_eq!(
@@ -540,7 +537,7 @@ fn line_numbers() {
         SourceLocation { line: 1, column: 7 }
     );
     assert_eq!(
-        input.try_next_including_whitespace_and_comments(),
+        input.next_including_whitespace_and_comments(),
         Ok(&Token::Comment("\n"))
     );
     assert_eq!(
@@ -548,7 +545,7 @@ fn line_numbers() {
         SourceLocation { line: 2, column: 3 }
     );
     assert_eq!(
-        input.try_next_including_whitespace(),
+        input.next_including_whitespace(),
         Ok(&Token::Ident("baz".into()))
     );
     assert_eq!(
@@ -558,7 +555,7 @@ fn line_numbers() {
     let state = input.state();
 
     assert_eq!(
-        input.try_next_including_whitespace(),
+        input.next_including_whitespace(),
         Ok(&Token::WhiteSpace("\r\n\n"))
     );
     assert_eq!(
@@ -572,7 +569,7 @@ fn line_numbers() {
     );
 
     assert_eq!(
-        input.try_next_including_whitespace(),
+        input.next_including_whitespace(),
         Ok(&Token::UnquotedUrl("u".into()))
     );
     assert_eq!(
@@ -581,14 +578,14 @@ fn line_numbers() {
     );
 
     assert_eq!(
-        input.try_next_including_whitespace(),
+        input.next_including_whitespace(),
         Ok(&Token::QuotedString("ab".into()))
     );
     assert_eq!(
         input.current_source_location(),
         SourceLocation { line: 7, column: 3 }
     );
-    assert!(input.try_next_including_whitespace().is_err());
+    assert!(input.next_including_whitespace().is_err());
 }
 
 #[test]
@@ -648,15 +645,15 @@ fn overflow() {
 fn line_delimited() {
     let mut input = ParserInput::new(" { foo ; bar } baz;,");
     let mut input = Parser::new(&mut input);
-    assert_eq!(input.try_next(), Ok(&Token::CurlyBracketBlock));
+    assert_eq!(input.next(), Ok(&Token::CurlyBracketBlock));
     assert!({
         let result: Result<_, ParseError<()>> =
             input.parse_until_after(Delimiter::Semicolon, |_| Ok(42));
         result
     }
     .is_err());
-    assert_eq!(input.try_next(), Ok(&Token::Comma));
-    assert!(input.try_next().is_err());
+    assert_eq!(input.next(), Ok(&Token::Comma));
+    assert!(input.next().is_err());
 }
 
 #[test]
@@ -843,7 +840,7 @@ fn no_stack_overflow_multiple_nested_blocks() {
     }
     let mut input = ParserInput::new(&input);
     let mut input = Parser::new(&mut input);
-    while input.try_next().is_ok() {}
+    while input.next().is_ok() {}
 }
 
 impl<'i> DeclarationParser<'i> for JsonParser {
@@ -859,7 +856,7 @@ impl<'i> DeclarationParser<'i> for JsonParser {
         let mut important = false;
         loop {
             let start = input.state();
-            if let Ok(mut token) = input.try_next_including_whitespace().map(|t| t.clone()) {
+            if let Ok(mut token) = input.next_including_whitespace().map(|t| t.clone()) {
                 // Hack to deal with css-parsing-tests assuming that
                 // `!important` in the middle of a declaration value is OK.
                 // This can never happen per spec
@@ -871,7 +868,7 @@ impl<'i> DeclarationParser<'i> for JsonParser {
                         break;
                     }
                     input.reset(&start);
-                    token = input.try_next_including_whitespace().unwrap().clone();
+                    token = input.next_including_whitespace().unwrap().clone();
                 }
                 value.push(one_component_value_to_json(token, input));
             } else {
@@ -962,7 +959,7 @@ impl<'i> RuleBodyItemParser<'i, Value, ()> for JsonParser {
 
 fn component_values_to_json(input: &mut Parser) -> Vec<Value> {
     let mut values = vec![];
-    while let Ok(token) = input.try_next_including_whitespace().map(|t| t.clone()) {
+    while let Ok(token) = input.next_including_whitespace().map(|t| t.clone()) {
         values.push(one_component_value_to_json(token, input));
     }
     values
@@ -1128,8 +1125,8 @@ fn parse_until_before_stops_at_delimiter_or_end_of_input() {
                 let _ = ix.parse_until_before::<_, _, ()>(equivalent.0, |ix| {
                     iy.parse_until_before::<_, _, ()>(equivalent.0, |iy| {
                         loop {
-                            let ox = ix.try_next();
-                            let oy = iy.try_next();
+                            let ox = ix.next();
+                            let oy = iy.next();
                             assert_eq!(ox, oy);
                             if ox.is_err() {
                                 break;
@@ -1148,17 +1145,17 @@ fn parser_maintains_current_line() {
     let mut input = ParserInput::new("ident ident;\nident ident ident;\nident");
     let mut parser = Parser::new(&mut input);
     assert_eq!(parser.current_line(), "ident ident;");
-    assert_eq!(parser.try_next(), Ok(&Token::Ident("ident".into())));
-    assert_eq!(parser.try_next(), Ok(&Token::Ident("ident".into())));
-    assert_eq!(parser.try_next(), Ok(&Token::Semicolon));
+    assert_eq!(parser.next(), Ok(&Token::Ident("ident".into())));
+    assert_eq!(parser.next(), Ok(&Token::Ident("ident".into())));
+    assert_eq!(parser.next(), Ok(&Token::Semicolon));
 
-    assert_eq!(parser.try_next(), Ok(&Token::Ident("ident".into())));
+    assert_eq!(parser.next(), Ok(&Token::Ident("ident".into())));
     assert_eq!(parser.current_line(), "ident ident ident;");
-    assert_eq!(parser.try_next(), Ok(&Token::Ident("ident".into())));
-    assert_eq!(parser.try_next(), Ok(&Token::Ident("ident".into())));
-    assert_eq!(parser.try_next(), Ok(&Token::Semicolon));
+    assert_eq!(parser.next(), Ok(&Token::Ident("ident".into())));
+    assert_eq!(parser.next(), Ok(&Token::Ident("ident".into())));
+    assert_eq!(parser.next(), Ok(&Token::Semicolon));
 
-    assert_eq!(parser.try_next(), Ok(&Token::Ident("ident".into())));
+    assert_eq!(parser.next(), Ok(&Token::Ident("ident".into())));
     assert_eq!(parser.current_line(), "ident");
 }
 
@@ -1167,9 +1164,9 @@ fn cdc_regression_test() {
     let mut input = ParserInput::new("-->x");
     let mut parser = Parser::new(&mut input);
     parser.skip_cdc_and_cdo();
-    assert_eq!(parser.try_next(), Ok(&Token::Ident("x".into())));
+    assert_eq!(parser.next(), Ok(&Token::Ident("x".into())));
     assert_eq!(
-        parser.try_next(),
+        parser.next(),
         Err(BasicParseError {
             kind: BasicParseErrorKind::EndOfInput,
             location: SourceLocation { line: 0, column: 5 }
@@ -1217,7 +1214,7 @@ fn parse_sourcemapping_comments() {
     for test in tests {
         let mut input = ParserInput::new(test.0);
         let mut parser = Parser::new(&mut input);
-        while parser.try_next_including_whitespace().is_ok() {}
+        while parser.next_including_whitespace().is_ok() {}
         assert_eq!(parser.current_source_map_url(), test.1);
     }
 }
@@ -1241,7 +1238,7 @@ fn parse_sourceurl_comments() {
     for test in tests {
         let mut input = ParserInput::new(test.0);
         let mut parser = Parser::new(&mut input);
-        while parser.try_next_including_whitespace().is_ok() {}
+        while parser.next_including_whitespace().is_ok() {}
         assert_eq!(parser.current_source_url(), test.1);
     }
 }
@@ -1252,7 +1249,7 @@ fn roundtrip_percentage_token() {
     fn test_roundtrip(value: &str) {
         let mut input = ParserInput::new(value);
         let mut parser = Parser::new(&mut input);
-        let token = parser.try_next().unwrap();
+        let token = parser.next().unwrap();
         assert_eq!(token.to_css_string(), value);
     }
     // Test simple number serialization
@@ -1307,7 +1304,7 @@ fn utf16_columns() {
 
         // Read all tokens.
         loop {
-            match parser.try_next() {
+            match parser.next() {
                 Err(BasicParseError {
                     kind: BasicParseErrorKind::EndOfInput,
                     ..

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -255,10 +255,10 @@ impl<'a> Tokenizer<'a> {
 
     #[inline]
     pub fn see_function(&mut self, name: &str) {
-        if self.var_or_env_functions == SeenStatus::LookingForThem {
-            if name.eq_ignore_ascii_case("var") || name.eq_ignore_ascii_case("env") {
-                self.var_or_env_functions = SeenStatus::SeenAtLeastOne;
-            }
+        if self.var_or_env_functions == SeenStatus::LookingForThem
+            && (name.eq_ignore_ascii_case("var") || name.eq_ignore_ascii_case("env"))
+        {
+            self.var_or_env_functions = SeenStatus::SeenAtLeastOne;
         }
     }
 
@@ -322,10 +322,12 @@ impl<'a> Tokenizer<'a> {
 
     pub fn current_source_line(&self) -> &'a str {
         let current = self.position();
-        let start = self.slice(SourcePosition(0)..current)
+        let start = self
+            .slice(SourcePosition(0)..current)
             .rfind(|c| matches!(c, '\r' | '\n' | '\x0C'))
             .map_or(0, |start| start + 1);
-        let end = self.slice(current..SourcePosition(self.input.len()))
+        let end = self
+            .slice(current..SourcePosition(self.input.len()))
             .find(|c| matches!(c, '\r' | '\n' | '\x0C'))
             .map_or(self.input.len(), |end| current.0 + end);
         self.slice(SourcePosition(start)..SourcePosition(end))
@@ -424,7 +426,10 @@ impl<'a> Tokenizer<'a> {
 
     #[inline]
     fn next_char(&self) -> char {
-        unsafe { self.input.get_unchecked(self.position().0..) }.chars().next().unwrap()
+        unsafe { self.input.get_unchecked(self.position().0..) }
+            .chars()
+            .next()
+            .unwrap()
     }
 
     // Given that a newline has been seen, advance over the newline
@@ -582,11 +587,11 @@ fn next_token<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, ()> {
         b'+' => {
             if (
                 tokenizer.has_at_least(1)
-                && matches!(tokenizer.byte_at(1), b'0'..=b'9')
+                && tokenizer.byte_at(1).is_ascii_digit()
             ) || (
                 tokenizer.has_at_least(2)
                 && tokenizer.byte_at(1) == b'.'
-                && matches!(tokenizer.byte_at(2), b'0'..=b'9')
+                && tokenizer.byte_at(2).is_ascii_digit()
             ) {
                 consume_numeric(tokenizer)
             } else {
@@ -598,11 +603,11 @@ fn next_token<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, ()> {
         b'-' => {
             if (
                 tokenizer.has_at_least(1)
-                && matches!(tokenizer.byte_at(1), b'0'..=b'9')
+                && tokenizer.byte_at(1).is_ascii_digit()
             ) || (
                 tokenizer.has_at_least(2)
                 && tokenizer.byte_at(1) == b'.'
-                && matches!(tokenizer.byte_at(2), b'0'..=b'9')
+                && tokenizer.byte_at(2).is_ascii_digit()
             ) {
                 consume_numeric(tokenizer)
             } else if tokenizer.starts_with(b"-->") {
@@ -617,8 +622,7 @@ fn next_token<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, ()> {
         },
         b'.' => {
             if tokenizer.has_at_least(1)
-                && matches!(tokenizer.byte_at(1), b'0'..=b'9'
-            ) {
+                && tokenizer.byte_at(1).is_ascii_digit() {
                 consume_numeric(tokenizer)
             } else {
                 tokenizer.advance(1);
@@ -1001,7 +1005,7 @@ fn byte_to_hex_digit(b: u8) -> Option<u32> {
 }
 
 fn byte_to_decimal_digit(b: u8) -> Option<u32> {
-    if b >= b'0' && b <= b'9' {
+    if b.is_ascii_digit() {
         Some((b - b'0') as u32)
     } else {
         None
@@ -1038,7 +1042,7 @@ fn consume_numeric<'a>(tokenizer: &mut Tokenizer<'a>) -> Token<'a> {
     let mut fractional_part: f64 = 0.;
     if tokenizer.has_at_least(1)
         && tokenizer.next_byte_unchecked() == b'.'
-        && matches!(tokenizer.byte_at(1), b'0'..=b'9')
+        && tokenizer.byte_at(1).is_ascii_digit()
     {
         is_integer = false;
         tokenizer.advance(1); // Consume '.'
@@ -1055,32 +1059,32 @@ fn consume_numeric<'a>(tokenizer: &mut Tokenizer<'a>) -> Token<'a> {
 
     let mut value = sign * (integral_part + fractional_part);
 
-    if tokenizer.has_at_least(1) && matches!(tokenizer.next_byte_unchecked(), b'e' | b'E') {
-        if matches!(tokenizer.byte_at(1), b'0'..=b'9')
+    if tokenizer.has_at_least(1)
+        && matches!(tokenizer.next_byte_unchecked(), b'e' | b'E')
+        && (tokenizer.byte_at(1).is_ascii_digit()
             || (tokenizer.has_at_least(2)
                 && matches!(tokenizer.byte_at(1), b'+' | b'-')
-                && matches!(tokenizer.byte_at(2), b'0'..=b'9'))
-        {
-            is_integer = false;
+                && tokenizer.byte_at(2).is_ascii_digit()))
+    {
+        is_integer = false;
+        tokenizer.advance(1);
+        let (has_sign, sign) = match tokenizer.next_byte_unchecked() {
+            b'-' => (true, -1.),
+            b'+' => (true, 1.),
+            _ => (false, 1.),
+        };
+        if has_sign {
             tokenizer.advance(1);
-            let (has_sign, sign) = match tokenizer.next_byte_unchecked() {
-                b'-' => (true, -1.),
-                b'+' => (true, 1.),
-                _ => (false, 1.),
-            };
-            if has_sign {
-                tokenizer.advance(1);
-            }
-            let mut exponent: f64 = 0.;
-            while let Some(digit) = byte_to_decimal_digit(tokenizer.next_byte_unchecked()) {
-                exponent = exponent * 10. + digit as f64;
-                tokenizer.advance(1);
-                if tokenizer.is_eof() {
-                    break;
-                }
-            }
-            value *= f64::powf(10., sign * exponent);
         }
+        let mut exponent: f64 = 0.;
+        while let Some(digit) = byte_to_decimal_digit(tokenizer.next_byte_unchecked()) {
+            exponent = exponent * 10. + digit as f64;
+            tokenizer.advance(1);
+            if tokenizer.is_eof() {
+                break;
+            }
+        }
+        value *= f64::powf(10., sign * exponent);
     }
 
     let int_value = if is_integer {
@@ -1339,7 +1343,7 @@ fn consume_unquoted_url<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, 
 }
 
 // (value, number of digits up to 6)
-fn consume_hex_digits<'a>(tokenizer: &mut Tokenizer<'a>) -> (u32, u32) {
+fn consume_hex_digits(tokenizer: &mut Tokenizer<'_>) -> (u32, u32) {
     let mut value = 0;
     let mut digits = 0;
     while digits < 6 && !tokenizer.is_eof() {

--- a/src/unicode_range.rs
+++ b/src/unicode_range.rs
@@ -24,7 +24,7 @@ pub struct UnicodeRange {
 
 impl UnicodeRange {
     /// https://drafts.csswg.org/css-syntax/#urange-syntax
-    pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, BasicParseError<'i>> {
+    pub fn parse<'i>(input: &mut Parser<'i, '_>) -> Result<Self, BasicParseError<'i>> {
         // <urange> =
         //   u '+' <ident-token> '?'* |
         //   u <dimension-token> '?'* |
@@ -57,7 +57,7 @@ impl UnicodeRange {
     }
 }
 
-fn parse_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), BasicParseError<'i>> {
+fn parse_tokens<'i>(input: &mut Parser<'i, '_>) -> Result<(), BasicParseError<'i>> {
     match input.next_including_whitespace()?.clone() {
         Token::Delim('+') => {
             match *input.next_including_whitespace()? {
@@ -123,15 +123,13 @@ fn parse_concatenated(text: &[u8]) -> Result<UnicodeRange, ()> {
             start: first_hex_value,
             end: first_hex_value,
         });
-    } else {
-        if let Some((&b'-', mut text)) = text.split_first() {
-            let (second_hex_value, hex_digit_count) = consume_hex(&mut text);
-            if hex_digit_count > 0 && hex_digit_count <= 6 && text.is_empty() {
-                return Ok(UnicodeRange {
-                    start: first_hex_value,
-                    end: second_hex_value,
-                });
-            }
+    } else if let Some((&b'-', mut text)) = text.split_first() {
+        let (second_hex_value, hex_digit_count) = consume_hex(&mut text);
+        if hex_digit_count > 0 && hex_digit_count <= 6 && text.is_empty() {
+            return Ok(UnicodeRange {
+                start: first_hex_value,
+                end: second_hex_value,
+            });
         }
     }
     Err(())

--- a/src/unicode_range.rs
+++ b/src/unicode_range.rs
@@ -58,9 +58,9 @@ impl UnicodeRange {
 }
 
 fn parse_tokens<'i>(input: &mut Parser<'i, '_>) -> Result<(), BasicParseError<'i>> {
-    match input.next_including_whitespace()?.clone() {
+    match input.try_next_including_whitespace()?.clone() {
         Token::Delim('+') => {
-            match *input.next_including_whitespace()? {
+            match *input.try_next_including_whitespace()? {
                 Token::Ident(_) => {}
                 Token::Delim('?') => {}
                 ref t => {
@@ -73,7 +73,7 @@ fn parse_tokens<'i>(input: &mut Parser<'i, '_>) -> Result<(), BasicParseError<'i
         Token::Dimension { .. } => parse_question_marks(input),
         Token::Number { .. } => {
             let after_number = input.state();
-            match input.next_including_whitespace() {
+            match input.try_next_including_whitespace() {
                 Ok(&Token::Delim('?')) => parse_question_marks(input),
                 Ok(&Token::Dimension { .. }) => {}
                 Ok(&Token::Number { .. }) => {}
@@ -89,7 +89,7 @@ fn parse_tokens<'i>(input: &mut Parser<'i, '_>) -> Result<(), BasicParseError<'i
 fn parse_question_marks(input: &mut Parser) {
     loop {
         let start = input.state();
-        match input.next_including_whitespace() {
+        match input.try_next_including_whitespace() {
             Ok(&Token::Delim('?')) => {}
             _ => {
                 input.reset(&start);

--- a/src/unicode_range.rs
+++ b/src/unicode_range.rs
@@ -58,9 +58,9 @@ impl UnicodeRange {
 }
 
 fn parse_tokens<'i>(input: &mut Parser<'i, '_>) -> Result<(), BasicParseError<'i>> {
-    match input.try_next_including_whitespace()?.clone() {
+    match input.next_including_whitespace()?.clone() {
         Token::Delim('+') => {
-            match *input.try_next_including_whitespace()? {
+            match *input.next_including_whitespace()? {
                 Token::Ident(_) => {}
                 Token::Delim('?') => {}
                 ref t => {
@@ -73,7 +73,7 @@ fn parse_tokens<'i>(input: &mut Parser<'i, '_>) -> Result<(), BasicParseError<'i
         Token::Dimension { .. } => parse_question_marks(input),
         Token::Number { .. } => {
             let after_number = input.state();
-            match input.try_next_including_whitespace() {
+            match input.next_including_whitespace() {
                 Ok(&Token::Delim('?')) => parse_question_marks(input),
                 Ok(&Token::Dimension { .. }) => {}
                 Ok(&Token::Number { .. }) => {}
@@ -89,7 +89,7 @@ fn parse_tokens<'i>(input: &mut Parser<'i, '_>) -> Result<(), BasicParseError<'i
 fn parse_question_marks(input: &mut Parser) {
     loop {
         let start = input.state();
-        match input.try_next_including_whitespace() {
+        match input.next_including_whitespace() {
             Ok(&Token::Delim('?')) => {}
             _ => {
                 input.reset(&start);


### PR DESCRIPTION
- Use case for better `cssparser-color` separation:
Access to private implementation items for parsers and other software using the crate.
- Example use case and motivation:
My own project. I use the crate to serialize and deserialize CSS3-compatible color data from user input and config files. This was impossible without these changes.
- Serde impls for `color` crate items are gated by a new `serde` feature in the inner crate.
- A few public functions were adjusted with new names, as suggested by `clippy` - caused a semantic conflict with std's `Iterator`.
- General refactoring. 

All checks passed on my fork, but I'm not familiar with the guidelines for commits for this repository. It's my first one here. I hope it's up to expectations. 😁
If something's up, be sure to comment.