### PR TITLE
Add a profiling cargo profile.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ phf =  { version = "0.11.2", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.0"
 
+[profile.profiling]
+inherits = "release"
+debug = true
+
 [features]
 bench = []
 dummy_match_byte = []


### PR DESCRIPTION
Useful for profiling via [samply](https://github.com/mstange/samply) or perf.