### PR TITLE
Make PredefinedColorSpace follow the convention of parse() and ToCss

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.33.0"
+version = "0.34.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 
 description = "Rust implementation of CSS Syntax Level 3"
@@ -23,7 +23,7 @@ encoding_rs = "0.8"
 cssparser-macros = { path = "./macros", version = "0.6.1" }
 dtoa-short = "0.3"
 itoa = "1.0"
-phf =  { version = "0.11.2", features = ["macros"] }
+phf = { version = "0.11.2", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 smallvec = "1.0"
 

--- a/color/lib.rs
+++ b/color/lib.rs
@@ -18,7 +18,6 @@ use cssparser::color::{
 use cssparser::{match_ignore_ascii_case, CowRcStr, ParseError, Parser, ToCss, Token};
 use std::f32::consts::PI;
 use std::fmt;
-use std::str::FromStr;
 
 /// Return the named color with the given name.
 ///
@@ -402,13 +401,7 @@ fn parse_color_with_color_space<'i, 't, P>(
 where
     P: ColorParser<'i>,
 {
-    let color_space = {
-        let location = arguments.current_source_location();
-
-        let ident = arguments.expect_ident()?;
-        PredefinedColorSpace::from_str(ident)
-            .map_err(|_| location.new_unexpected_token_error(Token::Ident(ident.clone())))?
-    };
+    let color_space = PredefinedColorSpace::parse(arguments)?;
 
     let (c1, c2, c3, alpha) = parse_components(
         color_parser,

--- a/color/tests.rs
+++ b/color/tests.rs
@@ -215,7 +215,7 @@ impl ToJson for Color {
             Color::Oklab(ref c) => json!([c.lightness, c.a, c.b, c.alpha]),
             Color::Oklch(ref c) => json!([c.lightness, c.chroma, c.hue, c.alpha]),
             Color::ColorFunction(ref c) => {
-                json!([c.color_space.as_str(), c.c1, c.c2, c.c3, c.alpha])
+                json!([c.color_space.to_css_string(), c.c1, c.c2, c.c3, c.alpha])
             }
         }
     }


### PR DESCRIPTION
Also bump version to 0.34, because this is a breaking change.