### PR TITLE
Add support for * prefix in declaration names

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -211,6 +211,10 @@ where
             hex_escape(digit, dest)?;
             value = &value[1..];
         }
+        if b'*' == value.as_bytes()[0] {
+            dest.write_str("*")?;
+            value = &value[1..];
+        }
         serialize_name(value, dest)
     }
 }


### PR DESCRIPTION
Hey
This is a hacky fix for adding support of legacy `*` prefixes to `cssparser`.

Currently this fails to be parsed:
```css
p {
    *color: red;
}
```

And there is a good reason to it, This legacy syntax is only used for ie 6/7 and it's not valid css3 grammar too.

But some libraries and old codebases still depend on this kind of properties to work on old browsers.

I know this is not a correct way to do it, but if you have plans to add this feature to parser, i can prepare another fix that uses feature-gates in cargo.toml and has proper parsing methods for handling this kind of syntax.