### PR TITLE
Make create no_std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,12 @@ inherits = "release"
 debug = true
 
 [features]
+default = ["std"]
 bench = []
 dummy_match_byte = []
 # Useful for skipping tests when execution is slow, e.g., under miri
 skip_long_tests = []
+std = []
 
 [workspace]
 members = [".", "./macros", "./color"]

--- a/color/lib.rs
+++ b/color/lib.rs
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
+#![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
 
 //! Fairly complete css-color implementation.
@@ -11,13 +11,13 @@
 #[cfg(test)]
 mod tests;
 
+use core::f32::consts::PI;
+use core::fmt;
 use cssparser::color::{
     clamp_floor_256_f32, clamp_unit_f32, parse_hash_color, serialize_color_alpha,
     PredefinedColorSpace, OPAQUE,
 };
 use cssparser::{match_ignore_ascii_case, CowRcStr, ParseError, Parser, ToCss, Token};
-use std::f32::consts::PI;
-use std::fmt;
 
 /// Return the named color with the given name.
 ///

--- a/src/color.rs
+++ b/src/color.rs
@@ -15,7 +15,7 @@
 pub const OPAQUE: f32 = 1.0;
 
 use crate::{BasicParseError, Parser, ToCss, Token};
-use std::fmt;
+use core::fmt;
 
 /// Clamp a 0..1 number to a 0..255 range to u8.
 ///

--- a/src/cow_rc_str.rs
+++ b/src/cow_rc_str.rs
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::borrow::{Borrow, Cow};
-use std::rc::Rc;
-use std::{cmp, fmt, hash, marker, mem, ops, ptr, slice, str};
+use alloc::borrow::{Borrow, Cow};
+use alloc::rc::Rc;
+use alloc::string::String;
+use core::{cmp, fmt, hash, marker, mem, ops, ptr, slice, str};
 
 /// A string that is either shared (heap-allocated and reference-counted) or borrowed.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
+#![cfg_attr(not(feature = "std"), no_std)]
 #![crate_name = "cssparser"]
 #![crate_type = "rlib"]
 #![cfg_attr(feature = "bench", feature(test))]
@@ -66,6 +66,8 @@ fn parse_border_spacing(_context: &ParserContext, input: &mut Parser)
 */
 
 #![recursion_limit = "200"] // For color::parse_color_keyword
+
+extern crate alloc;
 
 pub use crate::cow_rc_str::CowRcStr;
 pub use crate::from_bytes::{stylesheet_encoding, EncodingSupport};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 /// Expands to a `match` expression with string patterns,
 /// matching case-insensitively in the ASCII range.
@@ -191,7 +191,7 @@ pub fn _cssparser_internal_to_lowercase<'a>(
         // `buffer` was initialized to a copy of `input`
         // (which is `&str` so well-formed UTF-8)
         // then ASCII-lowercased (which preserves UTF-8 well-formedness):
-        unsafe { ::std::str::from_utf8_unchecked(buffer) }
+        unsafe { ::core::str::from_utf8_unchecked(buffer) }
     }
 
     Some(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,10 +4,11 @@
 
 use crate::cow_rc_str::CowRcStr;
 use crate::tokenizer::{SourceLocation, SourcePosition, Token, Tokenizer};
+use alloc::vec::Vec;
+use core::fmt;
+use core::ops::BitOr;
+use core::ops::Range;
 use smallvec::SmallVec;
-use std::fmt;
-use std::ops::BitOr;
-use std::ops::Range;
 
 /// A capture of the internal state of a `Parser` (including the position within the input),
 /// obtained from the `Parser::position` method.
@@ -224,6 +225,7 @@ impl<'i, E: fmt::Display> fmt::Display for ParseError<'i, E> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'i, E: fmt::Display + fmt::Debug> std::error::Error for ParseError<'i, E> {}
 
 /// The owned input for a parser.

--- a/src/rules_and_declarations.rs
+++ b/src/rules_and_declarations.rs
@@ -199,7 +199,7 @@ pub struct RuleBodyParser<'i, 't, 'a, P, I, E> {
     /// The parser given to `DeclarationListParser::new`
     pub parser: &'a mut P,
 
-    _phantom: std::marker::PhantomData<(I, E)>,
+    _phantom: core::marker::PhantomData<(I, E)>,
 }
 
 /// A parser for a rule body item.
@@ -235,7 +235,7 @@ impl<'i, 't, 'a, P, I, E> RuleBodyParser<'i, 't, 'a, P, I, E> {
         Self {
             input,
             parser,
-            _phantom: std::marker::PhantomData,
+            _phantom: core::marker::PhantomData,
         }
     }
 }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -3,9 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::match_byte;
+use alloc::string::String;
+use core::fmt::{self, Write};
+use core::str;
 use dtoa_short::Notation;
-use std::fmt::{self, Write};
-use std::str;
 
 use super::Token;
 

--- a/src/size_of_tests.rs
+++ b/src/size_of_tests.rs
@@ -9,7 +9,7 @@ macro_rules! size_of_test {
     ($testname: ident, $t: ty, $expected_min_size: expr, $expected_max_size: expr) => {
         #[test]
         fn $testname() {
-            let new = ::std::mem::size_of::<$t>();
+            let new = ::core::mem::size_of::<$t>();
             if new < $expected_min_size {
                 panic!(
                     "Your changes have decreased the stack size of {} from {} to {}. \
@@ -39,7 +39,7 @@ macro_rules! size_of_test {
 
 // Some of these assume 64-bit
 size_of_test!(token, Token, 32);
-size_of_test!(std_cow_str, std::borrow::Cow<'static, str>, 24, 32);
+size_of_test!(std_cow_str, alloc::borrow::Cow<'static, str>, 24, 32);
 size_of_test!(cow_rc_str, CowRcStr, 16);
 
 size_of_test!(tokenizer, crate::tokenizer::Tokenizer, 72);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -7,8 +7,11 @@
 use self::Token::*;
 use crate::cow_rc_str::CowRcStr;
 use crate::parser::ParserState;
-use std::char;
-use std::ops::Range;
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::char;
+use core::ops::Range;
 
 #[cfg(not(feature = "dummy_match_byte"))]
 use cssparser_macros::match_byte;

--- a/src/unicode_range.rs
+++ b/src/unicode_range.rs
@@ -6,8 +6,8 @@
 
 use crate::tokenizer::Token;
 use crate::{BasicParseError, Parser, ToCss};
-use std::char;
-use std::fmt;
+use core::char;
+use core::fmt;
 
 /// One contiguous range of code points.
 ///


### PR DESCRIPTION
Make crate no_std while keeping it backwards compatible with a default `std` feature enabled(only used to impl Error for ParseError).