### PR TITLE
Implement `MallocSizeOf` for cssparser types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
         features:
           -
           - --features dummy_match_byte
+          - --features malloc_size_of
         include:
           - toolchain: nightly
             features: --features bench

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.34.0"
+version = "0.34.1"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 
 description = "Rust implementation of CSS Syntax Level 3"
@@ -25,6 +25,7 @@ dtoa-short = "0.3"
 itoa = "1.0"
 phf = { version = "0.11.2", features = ["macros"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
+malloc_size_of = { version = "0.1", default-features = false, optional = true }
 smallvec = "1.0"
 
 [profile.profiling]

--- a/src/from_bytes.rs
+++ b/src/from_bytes.rs
@@ -24,9 +24,9 @@ pub trait EncodingSupport {
 ///
 /// * `css_bytes`: A byte string.
 /// * `protocol_encoding`: The encoding label, if any, defined by HTTP or equivalent protocol.
-///     (e.g. via the `charset` parameter of the `Content-Type` header.)
+///   (e.g. via the `charset` parameter of the `Content-Type` header.)
 /// * `environment_encoding`: An optional `Encoding` object for the [environment encoding]
-///     (https://drafts.csswg.org/css-syntax/#environment-encoding), if any.
+///   (https://drafts.csswg.org/css-syntax/#environment-encoding), if any.
 ///
 /// Returns the encoding to use.
 pub fn stylesheet_encoding<E>(

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -466,6 +466,9 @@ pub enum TokenSerializationType {
     Other,
 }
 
+#[cfg(feature = "malloc_size_of")]
+malloc_size_of::malloc_size_of_is_0!(TokenSerializationType);
+
 impl TokenSerializationType {
     /// Return a value that represents the absence of a token, e.g. before the start of the input.
     #[deprecated(

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -533,6 +533,9 @@ impl<'a> Tokenizer<'a> {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
 pub struct SourcePosition(pub(crate) usize);
 
+#[cfg(feature = "malloc_size_of")]
+malloc_size_of::malloc_size_of_is_0!(SourcePosition);
+
 impl SourcePosition {
     /// Returns the current byte index in the original input.
     #[inline]
@@ -551,6 +554,9 @@ pub struct SourceLocation {
     /// Column numbers are counted in UTF-16 code units.
     pub column: u32,
 }
+
+#[cfg(feature = "malloc_size_of")]
+malloc_size_of::malloc_size_of_is_0!(SourceLocation);
 
 fn next_token<'a>(tokenizer: &mut Tokenizer<'a>) -> Result<Token<'a>, ()> {
     if tokenizer.is_eof() {


### PR DESCRIPTION
Now that [malloc_size_of](https://github.com/servo/malloc_size_of) is published to crates.io we are moving the trait implementations of [MallocSizeOf](https://docs.rs/malloc_size_of/latest/malloc_size_of/trait.MallocSizeOf.html) and related traits into the crates that define the types. This will avoid the situation where depending on `malloc_size_of` pulls in a large number of dependencies.

This PR adds the implementation of `MallocSizeOf` to the `cssparser` crate.