### PR TITLE
Bump version to v0.35.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.34.1"
+version = "0.35.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 
 description = "Rust implementation of CSS Syntax Level 3"

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser-color"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>"]
 description = "Color implementation based on cssparser"
 documentation = "https://docs.rs/cssparser-color/"
@@ -12,7 +12,7 @@ edition = "2021"
 path = "lib.rs"
 
 [dependencies]
-cssparser = { path = "..", version = "0.34" }
+cssparser = { path = "..", version = "0.35" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]


### PR DESCRIPTION
Can we get a new release of `cssparser`?

Servo depends on `cssparser` from crates.io, and the latest version of Stylo depends on unreleased breaking changes to `cssparser`.