### PR TITLE
disable the 'size_of_tests' on 32-bit architectures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ mod parser;
 mod serializer;
 mod unicode_range;
 
-#[cfg(test)]
+#[cfg(all(test,target_pointer_width = "64"))]
 mod size_of_tests;
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
As these tests doesn't seem to be written in a portable manner for 32-bit.

from: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/cssparser/debian/patches/disable-sizeof-tests-on-32-bit.diff