### PR TITLE
Fix is_ident_start signature to take immutable reference

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -891,7 +891,7 @@ fn consume_quoted_string<'a>(
 }
 
 #[inline]
-fn is_ident_start(tokenizer: &mut Tokenizer) -> bool {
+fn is_ident_start(tokenizer: &Tokenizer) -> bool {
     !tokenizer.is_eof()
         && match_byte! { tokenizer.next_byte_unchecked(),
             b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'\0' => true,


### PR DESCRIPTION
This PR changes the signature of is_ident_start to accept &Tokenizer instead of &mut Tokenizer, since it does not need mutable access.