### PR TITLE
Make all proc macros optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,13 +21,11 @@ jobs:
           - 1.68.0
         features:
           -
-          - --features dummy_match_byte
+          - --no-default-features
           - --features malloc_size_of
         include:
           - toolchain: nightly
             features: --features bench
-          - toolchain: nightly
-            features: --features bench,dummy_match_byte
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.68.0
+          - 1.71.0
         features:
           -
           - --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["css", "syntax", "parser"]
 license = "MPL-2.0"
 edition = "2018"
-rust-version = "1.68"
+rust-version = "1.71"
 
 exclude = ["src/css-parsing-tests/**", "src/big-data-url.css"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ encoding_rs = "0.8"
 cssparser-macros = { path = "./macros", version = "0.6.1", optional = true }
 dtoa-short = "0.3"
 itoa = "1.0"
-phf = { version = "0.13.1", features = ["macros"] }
+phf = { version = "0.13.1", features = ["macros"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 malloc_size_of = { version = "0.1", default-features = false, optional = true }
 smallvec = "1.0"
@@ -33,9 +33,10 @@ inherits = "release"
 debug = true
 
 [features]
-default = ["fast_match_byte"]
+default = ["fast_match_byte", "fast_match_color"]
 bench = []
 fast_match_byte = ["dep:cssparser-macros"]
+fast_match_color = ["dep:phf"]
 # Useful for skipping tests when execution is slow, e.g., under miri
 skip_long_tests = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ difference = "2.0"
 encoding_rs = "0.8"
 
 [dependencies]
-cssparser-macros = { path = "./macros", version = "0.6.1" }
+cssparser-macros = { path = "./macros", version = "0.6.1", optional = true }
 dtoa-short = "0.3"
 itoa = "1.0"
 phf = { version = "0.13.1", features = ["macros"] }
@@ -35,7 +35,7 @@ debug = true
 [features]
 default = ["fast_match_byte"]
 bench = []
-fast_match_byte = []
+fast_match_byte = ["dep:cssparser-macros"]
 # Useful for skipping tests when execution is slow, e.g., under miri
 skip_long_tests = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,21 @@ rust-version = "1.68"
 
 exclude = ["src/css-parsing-tests/**", "src/big-data-url.css"]
 
+[dependencies]
+dtoa-short = "0.3"
+itoa = "1.0"
+smallvec = "1.0"
+
+# Optional dependencies
+cssparser-macros = { path = "./macros", version = "0.6.1", optional = true }
+malloc_size_of = { version = "0.1", default-features = false, optional = true }
+phf = { version = "0.13.1", features = ["macros"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
+
 [dev-dependencies]
 serde_json = "1.0.25"
 difference = "2.0"
 encoding_rs = "0.8"
-
-[dependencies]
-cssparser-macros = { path = "./macros", version = "0.6.1", optional = true }
-dtoa-short = "0.3"
-itoa = "1.0"
-phf = { version = "0.13.1", features = ["macros"], optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
-malloc_size_of = { version = "0.1", default-features = false, optional = true }
-smallvec = "1.0"
 
 [profile.profiling]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,9 @@ inherits = "release"
 debug = true
 
 [features]
+default = ["fast_match_byte"]
 bench = []
-dummy_match_byte = []
+fast_match_byte = []
 # Useful for skipping tests when execution is slow, e.g., under miri
 skip_long_tests = []
 

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://docs.rs/cssparser-color/"
 repository = "https://github.com/servo/rust-cssparser"
 license = "MPL-2.0"
 edition = "2021"
+rust-version = "1.71"
 
 [lib]
 path = "lib.rs"

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -12,10 +12,11 @@ edition = "2021"
 path = "lib.rs"
 
 [dependencies]
-cssparser = { path = "..", version = "0.36" }
+cssparser = { path = "..", version = "0.36", default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
+default = ["cssparser/default"]
 serde = ["cssparser/serde", "dep:serde"]
 
 [dev-dependencies]

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -6,38 +6,6 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 
-#[proc_macro]
-pub fn _cssparser_internal_max_len(input: TokenStream) -> TokenStream {
-    struct Input {
-        max_length: usize,
-    }
-
-    impl syn::parse::Parse for Input {
-        fn parse(input: syn::parse::ParseStream) -> syn::parse::Result<Self> {
-            let mut max_length = 0;
-            while !input.is_empty() {
-                if input.peek(syn::Token![_]) {
-                    input.parse::<syn::Token![_]>().unwrap();
-                    continue;
-                }
-                let lit: syn::LitStr = input.parse()?;
-                let value = lit.value();
-                if value.to_ascii_lowercase() != value {
-                    return Err(syn::Error::new(lit.span(), "must be ASCII-lowercase"));
-                }
-                max_length = max_length.max(value.len());
-            }
-            Ok(Input { max_length })
-        }
-    }
-
-    let Input { max_length } = syn::parse_macro_input!(input);
-    quote::quote!(
-        pub(super) const MAX_LENGTH: usize = #max_length;
-    )
-    .into()
-}
-
 fn get_byte_from_lit(lit: &syn::Lit) -> u8 {
     if let syn::Lit::Byte(ref byte) = *lit {
         byte.value()

--- a/src/color.rs
+++ b/src/color.rs
@@ -172,7 +172,7 @@ pub fn parse_hash_color(value: &[u8]) -> Result<(u8, u8, u8, f32), ()> {
     })
 }
 
-ascii_case_insensitive_phf_map! {
+ascii_case_insensitive_map! {
     named_colors -> (u8, u8, u8) = {
         "black" => (0, 0, 0),
         "silver" => (192, 192, 192),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,39 @@ pub use crate::serializer::{serialize_identifier, serialize_name, serialize_stri
 pub use crate::serializer::{CssStringWriter, ToCss, TokenSerializationType};
 pub use crate::tokenizer::{SourceLocation, SourcePosition, Token};
 pub use crate::unicode_range::UnicodeRange;
-pub use cssparser_macros::*;
+pub use cssparser_macros::_cssparser_internal_max_len;
+
+#[cfg(feature = "fast_match_byte")]
+pub use cssparser_macros::match_byte;
+
+#[cfg(not(feature = "fast_match_byte"))]
+#[macro_use]
+mod mac {
+    /// Expand a TokenStream corresponding to the `match_byte` macro.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,ignore
+    /// match_byte! { tokenizer.next_byte_unchecked(),
+    ///     b'a'..b'z' => { ... }
+    ///     b'0'..b'9' => { ... }
+    ///     b'\n' | b'\\' => { ... }
+    ///     foo => { ... }
+    ///  }
+    ///  ```
+    ///
+    #[macro_export]
+    macro_rules! match_byte {
+      ($value:expr, $($rest:tt)* ) => {
+          match $value {
+              $(
+                  $rest
+              )+
+          }
+      };
+  }
+}
+
 #[doc(hidden)]
 pub use phf as _cssparser_internal_phf;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,6 @@ pub use crate::serializer::{serialize_identifier, serialize_name, serialize_stri
 pub use crate::serializer::{CssStringWriter, ToCss, TokenSerializationType};
 pub use crate::tokenizer::{SourceLocation, SourcePosition, Token};
 pub use crate::unicode_range::UnicodeRange;
-pub use cssparser_macros::_cssparser_internal_max_len;
 
 #[cfg(feature = "fast_match_byte")]
 pub use cssparser_macros::match_byte;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,9 @@ mod mac {
   }
 }
 
+// Re-exporting phf here means that the crate using the ascii_case_insensitive_phf_map macro do
+// do not have to depend on phf directly.
+#[cfg(feature = "fast_match_color")]
 #[doc(hidden)]
 pub use phf as _cssparser_internal_phf;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -34,22 +34,34 @@ macro_rules! match_ignore_ascii_case {
     ( $input:expr,
         $(
             $( #[$meta: meta] )*
-            $( $pattern: pat )|+ $( if $guard: expr )? => $then: expr
+            $( $pattern:literal )|+ $( if $guard: expr )? => $then: expr
         ),+
+        $(,_ => $fallback:expr)?
         $(,)?
     ) => {
         {
-            // This dummy module works around the feature gate
-            // `error[E0658]: procedural macros cannot be expanded to statements`
-            // by forcing the macro to be in an item context
-            // rather than expression/statement context,
-            // even though the macro only expands to items.
-            mod cssparser_internal {
-                $crate::_cssparser_internal_max_len! {
-                    $( $( $pattern )+ )+
+            #[inline(always)]
+            const fn const_usize_max(a: usize, b: usize) -> usize {
+                if a > b {
+                    a
+                } else {
+                    b
                 }
             }
-            $crate::_cssparser_internal_to_lowercase!($input, cssparser_internal::MAX_LENGTH => lowercase);
+
+            const MAX_LENGTH : usize = {
+                let mut maxlen : usize = 0;
+                $(
+                    $( #[$meta] )*
+                    // {} is necessary to work around "[E0658]: attributes on expressions are experimental"
+                    {
+                        $( maxlen = const_usize_max(maxlen, $pattern.len()); )+
+                    }
+                )+
+                maxlen
+            };
+
+            $crate::_cssparser_internal_to_lowercase!($input, MAX_LENGTH => lowercase);
             // "A" is a short string that we know is different for every string pattern,
             // since we’ve verified that none of them include ASCII upper case letters.
             match lowercase.unwrap_or("A") {
@@ -57,6 +69,7 @@ macro_rules! match_ignore_ascii_case {
                     $( #[$meta] )*
                     $( $pattern )|+ $( if $guard )? => $then,
                 )+
+                $(_ => $fallback,)?
             }
         }
     };
@@ -95,12 +108,20 @@ macro_rules! ascii_case_insensitive_phf_map {
     ($name: ident -> $ValueType: ty = { $( $key: tt => $value: expr, )+ }) => {
         use $crate::_cssparser_internal_phf as phf;
 
-        // See macro above for context.
-        mod cssparser_internal {
-            $crate::_cssparser_internal_max_len! {
-                $( $key )+
+        #[inline(always)]
+        const fn const_usize_max(a: usize, b: usize) -> usize {
+            if a > b {
+                a
+            } else {
+                b
             }
         }
+
+        const MAX_LENGTH : usize = {
+            let mut maxlen : usize = 0;
+            $( maxlen = const_usize_max(maxlen, ($key).len()); )+
+            maxlen
+        };
 
         static MAP: phf::Map<&'static str, $ValueType> = phf::phf_map! {
             $(
@@ -122,7 +143,7 @@ macro_rules! ascii_case_insensitive_phf_map {
             }
 
             fn get(input: &str) -> Option<&'static $ValueType> {
-                $crate::_cssparser_internal_to_lowercase!(input, cssparser_internal::MAX_LENGTH => lowercase);
+                $crate::_cssparser_internal_to_lowercase!(input, MAX_LENGTH => lowercase);
                 MAP.get(lowercase?)
             }
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -75,6 +75,8 @@ macro_rules! match_ignore_ascii_case {
     };
 }
 
+#[cfg(not(feature = "fast_match_color"))]
+#[macro_export]
 /// Define a function `$name(&str) -> Option<&'static $ValueType>`
 ///
 /// The function finds a match for the input string
@@ -88,7 +90,7 @@ macro_rules! match_ignore_ascii_case {
 /// # fn main() {}  // Make doctest not wrap everything in its own main
 ///
 /// fn color_rgb(input: &str) -> Option<(u8, u8, u8)> {
-///     cssparser::ascii_case_insensitive_phf_map! {
+///     cssparser::ascii_case_insensitive_map! {
 ///         keywords -> (u8, u8, u8) = {
 ///             "red" => (255, 0, 0),
 ///             "green" => (0, 255, 0),
@@ -100,6 +102,71 @@ macro_rules! match_ignore_ascii_case {
 /// ```
 ///
 /// You can also iterate over the map entries by using `keywords::entries()`.
+macro_rules! ascii_case_insensitive_map {
+    ($name: ident -> $ValueType: ty = { $( $key: tt => $value: expr ),+ }) => {
+        ascii_case_insensitive_map!($name -> $ValueType = { $( $key => $value, )+ })
+    };
+    ($name: ident -> $ValueType: ty = { $( $key: tt => $value: expr, )+ }) => {
+
+        // While the obvious choice for this would be an inner module, it's not possible to
+        // reference from types from there, see:
+        // <https://github.com/rust-lang/rust/issues/114369>
+        //
+        // So we abuse a struct with static associated functions instead.
+        #[allow(non_camel_case_types)]
+        struct $name;
+        impl $name {
+            #[allow(dead_code)]
+            fn entries() -> impl Iterator<Item = (&'static &'static str, &'static $ValueType)> {
+                [ $((&$key, &$value),)* ].iter().copied()
+            }
+
+            fn get(input: &str) -> Option<&'static $ValueType> {
+                $crate::match_ignore_ascii_case!(input,
+                    $($key => Some(&$value),)*
+                    _ => None,
+                )
+            }
+        }
+    }
+}
+
+#[cfg(feature = "fast_match_color")]
+#[macro_export]
+/// Define a function `$name(&str) -> Option<&'static $ValueType>`
+///
+/// The function finds a match for the input string
+/// in a [`phf` map](https://github.com/sfackler/rust-phf)
+/// and returns a reference to the corresponding value.
+/// Matching is case-insensitive in the ASCII range.
+///
+/// ## Example:
+///
+/// ```rust
+/// # fn main() {}  // Make doctest not wrap everything in its own main
+///
+/// fn color_rgb(input: &str) -> Option<(u8, u8, u8)> {
+///     cssparser::ascii_case_insensitive_map! {
+///         keywords -> (u8, u8, u8) = {
+///             "red" => (255, 0, 0),
+///             "green" => (0, 255, 0),
+///             "blue" => (0, 0, 255),
+///         }
+///     }
+///     keywords::get(input).cloned()
+/// }
+/// ```
+///
+/// You can also iterate over the map entries by using `keywords::entries()`.
+macro_rules! ascii_case_insensitive_map {
+    ($($any:tt)+) => {
+        $crate::ascii_case_insensitive_phf_map!($($any)+);
+    };
+}
+
+/// Fast implementation of `ascii_case_insensitive_map!` using a phf map.
+/// See `ascii_case_insensitive_map!` above for docs
+#[cfg(feature = "fast_match_color")]
 #[macro_export]
 macro_rules! ascii_case_insensitive_phf_map {
     ($name: ident -> $ValueType: ty = { $( $key: tt => $value: expr ),+ }) => {
@@ -123,7 +190,7 @@ macro_rules! ascii_case_insensitive_phf_map {
             maxlen
         };
 
-        static MAP: phf::Map<&'static str, $ValueType> = phf::phf_map! {
+        static __MAP: phf::Map<&'static str, $ValueType> = phf::phf_map! {
             $(
                 $key => $value,
             )*
@@ -139,12 +206,12 @@ macro_rules! ascii_case_insensitive_phf_map {
         impl $name {
             #[allow(dead_code)]
             fn entries() -> impl Iterator<Item = (&'static &'static str, &'static $ValueType)> {
-                MAP.entries()
+                __MAP.entries()
             }
 
             fn get(input: &str) -> Option<&'static $ValueType> {
                 $crate::_cssparser_internal_to_lowercase!(input, MAX_LENGTH => lowercase);
-                MAP.get(lowercase?)
+                __MAP.get(lowercase?)
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -659,9 +659,7 @@ impl<'i: 't, 't> Parser<'i, 't> {
             .input
             .cached_token
             .as_ref()
-            .map_or(false, |cached_token| {
-                cached_token.start_position == token_start_position
-            });
+            .is_some_and(|cached_token| cached_token.start_position == token_start_position);
         let token = if using_cached_token {
             let cached_token = self.input.cached_token.as_ref().unwrap();
             self.input.tokenizer.reset(&cached_token.end_state);

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -2,9 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::match_byte;
 use std::fmt::{self, Write};
 use std::str;
+
+#[cfg(feature = "fast_match_byte")]
+pub use crate::match_byte;
 
 use super::Token;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1333,7 +1333,7 @@ fn utf16_columns() {
 #[test]
 fn servo_define_css_keyword_enum() {
     macro_rules! define_css_keyword_enum {
-        (pub enum $name:ident { $($variant:ident = $css:pat,)+ }) => {
+        (pub enum $name:ident { $($variant:ident = $css:literal,)+ }) => {
             #[derive(PartialEq, Debug)]
             pub enum $name {
                 $($variant),+

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1085,7 +1085,7 @@ fn one_component_value_to_json(token: Token, input: &mut Parser) -> Value {
 /// including in string literals.
 #[test]
 fn procedural_masquerade_whitespace() {
-    ascii_case_insensitive_phf_map! {
+    ascii_case_insensitive_map! {
         map -> () = {
             "  \t\n" => ()
         }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -10,19 +10,8 @@ use crate::parser::{ArbitrarySubstitutionFunctions, ParserState};
 use std::char;
 use std::ops::Range;
 
-#[cfg(not(feature = "dummy_match_byte"))]
-use cssparser_macros::match_byte;
-
-#[cfg(feature = "dummy_match_byte")]
-macro_rules! match_byte {
-    ($value:expr, $($rest:tt)* ) => {
-        match $value {
-            $(
-                $rest
-            )+
-        }
-    };
-}
+#[cfg(feature = "fast_match_byte")]
+pub use crate::match_byte;
 
 /// One of the pieces the CSS input is broken into.
 ///


### PR DESCRIPTION
This PR makes all proc macros optional behind feature flags (and removes one completely, replacing it with const evaluation):

- Replace the `dummy_match_byte` feature (which **disables** the optimised `match_byte!` macro and replaces it with a simple `match` statement) with a `fast_match_byte` feature which **enables** the optimised `match_byte!` macro. This feature is enabled by default, but means if you build with `--no-default-features` then you don't get the proc macro.
- Replace the `_cssparser_internal_max_len` proc macro with const evaluation.
- Building on the above two changes, make the `cssparser-macros` dep optional (only enabled by `fast_match_byte` feature)
- ~~Improve the syntax of the `ascii_case_insensitive_phf_map!` macro (see below)~~ removed
- Make `phf` optional for color keyword lookup. This is gated behind a `fast_match_color` feature flag. When the flag is disabled the 

All of the new feature flags are enabled by default, so if you use `cssparser` with default features enabled there is no change except for the `ascii_case_insensitive_phf_map!` macro syntax.

**I have also bumped MSRV from 1.68 to 1.71. This is not actually related to this PR, but is required by recent patch versions of `syn` (in fact, with this PR `cssparser` builds down to 1.63 with default features disabled, but I figure 1.71 is probably old enough?)**

With this PR dependency tree with no default features is just:

```
cssparser v0.35.0 (/Users/nico/code/oss/cssparser)
├── dtoa-short v0.3.3
│   └── dtoa v0.4.8
├── itoa v1.0.6
└── smallvec v1.10.0
```

With default features it is:

```
cssparser v0.35.0 (/Users/nico/code/oss/cssparser)
├── cssparser-macros v0.6.1 (proc-macro) (/Users/nico/code/oss/cssparser/macros)
│   ├── quote v1.0.38
│   │   └── proc-macro2 v1.0.101
│   │       └── unicode-ident v1.0.8
│   └── syn v2.0.98
│       ├── proc-macro2 v1.0.101 (*)
│       ├── quote v1.0.38 (*)
│       └── unicode-ident v1.0.8
├── dtoa-short v0.3.3
│   └── dtoa v0.4.8
├── itoa v1.0.6
├── phf v0.13.1
│   ├── phf_macros v0.13.1 (proc-macro)
│   │   ├── phf_generator v0.13.1
│   │   │   ├── fastrand v2.3.0
│   │   │   └── phf_shared v0.13.1
│   │   │       └── siphasher v1.0.1
│   │   ├── phf_shared v0.13.1 (*)
│   │   ├── proc-macro2 v1.0.101 (*)
│   │   ├── quote v1.0.38 (*)
│   │   └── syn v2.0.98 (*)
│   └── phf_shared v0.13.1 (*)
└── smallvec v1.10.0
```

<details><summary><del>`ascii_case_insensitive_phf_map` syntax change</del> removed</summary>


### `ascii_case_insensitive_phf_map` syntax

The macro syntax was previously:

```rust
cssparser::ascii_case_insensitive_phf_map! {
    keywords -> (u8, u8, u8) = {
        "red" => (255, 0, 0),
        "green" => (0, 255, 0),
        "blue" => (0, 0, 255),
    }
}
```

```rust
cssparser::ascii_case_insensitive_phf_map! {
    static keywords : (u8, u8, u8) = {
        "red" => (255, 0, 0),
        "green" => (0, 255, 0),
        "blue" => (0, 0, 255),
    }
}
```

This uses the conventional Rust `:` syntax for defining a type. And also makes it clearer that the `keywords` bit is an `ident` that is being defined.

</details>