### PR TITLE
Make color and macros crates default members

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,29 +41,26 @@ jobs:
         run: cargo fmt --check && cargo clippy -- -Dwarnings
 
       - name: Cargo build
-        run: cargo build ${{ matrix.features }}
+        run: cargo build -p cssparser ${{ matrix.features }}
 
       - name: Cargo doc
-        run: cargo doc ${{ matrix.features }}
+        run: cargo doc -p cssparser ${{ matrix.features }}
 
       - name: Cargo test
-        run: cargo test ${{ matrix.features }}
+        run: cargo test -p cssparser ${{ matrix.features }}
 
       - name: macros build
-        run: cargo build
-        working-directory: macros
+        run: cargo build -p cssparser-macros
 
       - name: Color build
-        run: cargo build
-        working-directory: color
+        run: cargo build -p cssparser-color
 
       - name: Color test
-        run: cargo test
-        working-directory: color
+        run: cargo test -p cssparser-color
 
       - name: Cargo miri test
         if: "matrix.toolchain == 'nightly'"
-        run: cargo miri test --features skip_long_tests ${{ matrix.features }}
+        run: cargo miri test -p cssparser --features skip_long_tests ${{ matrix.features }}
 
   build_result:
     name: Result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ skip_long_tests = []
 
 [workspace]
 members = [".", "./macros", "./color"]
+default-members = [".", "./macros", "./color"]


### PR DESCRIPTION
This means that running unqualified `cargo check/build/test/clippy` will run against all 3 crates by default, making it harder to accidentally miss build issues in `cssparser-color` crate which previously wouldn't be checked by default.