### PR TITLE
Release v0.37.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser"
-version = "0.36.0"
+version = "0.37.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 
 description = "Rust implementation of CSS Syntax Level 3"
@@ -20,7 +20,7 @@ itoa = "1.0"
 smallvec = "1.0"
 
 # Optional dependencies
-cssparser-macros = { path = "./macros", version = "0.6.1", optional = true }
+cssparser-macros = { path = "./macros", version = "0.7.0", optional = true }
 malloc_size_of = { version = "0.1", default-features = false, optional = true }
 phf = { version = "0.13.1", features = ["macros"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser-color"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>"]
 description = "Color implementation based on cssparser"
 documentation = "https://docs.rs/cssparser-color/"
@@ -13,7 +13,7 @@ rust-version = "1.71"
 path = "lib.rs"
 
 [dependencies]
-cssparser = { path = "..", version = "0.36", default-features = false }
+cssparser = { path = "..", version = "0.37", default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssparser-macros"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 description = "Procedural macros for cssparser"
 documentation = "https://docs.rs/cssparser-macros/"


### PR DESCRIPTION
A release that includes https://github.com/servo/rust-cssparser/pull/425 (I'm wanting to use this for value parsing in Taffy, which is currently very low dependency).

Note that `cssparser-color` v0.4 was never published (see https://github.com/servo/rust-cssparser/issues/420). And I think it would still make sense to do so. I believe that all that should be required is to checkout commit 9339ddd71443463dfb85d1185ad50cd98b34bc8f which did the version bump for `cssparser` 0.36 and `cssparser-color` 0.4, and run `cargo publish -p cssparser-color`.

It may make sense to align the version numbers of the `-color` and `-macros` crates with the main `cssparser` crate, but I have not done so in this PR.