### PR TITLE
macros: Allow syn 3.0.

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.29"
-syn = {version = "2", features = ["full", "extra-traits"]}
+syn = { version = ">=2,<4", features = ["full", "extra-traits"] }

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -71,7 +71,7 @@ fn parse_pat_to_table<'a>(
             }
         }
         _ => {
-            panic!("Unexpected pattern: {:?}. Buggy code ?", pat);
+            panic!("Unexpected or unsupported pattern: {:?}. Buggy code ?", pat);
         }
     }
 }
@@ -80,7 +80,7 @@ fn parse_pat_to_table<'a>(
 ///
 /// ## Example
 ///
-/// ```rust
+/// ```rust,ignore
 /// match_byte! { tokenizer.next_byte_unchecked(),
 ///     b'a'..b'z' => { ... }
 ///     b'0'..b'9' => { ... }
@@ -109,7 +109,6 @@ pub fn match_byte(input: TokenStream) -> TokenStream {
                     let mut arms = Vec::new();
                     while !input.is_empty() {
                         let arm = input.call(syn::Arm::parse)?;
-                        assert!(arm.guard.is_none(), "match_byte doesn't support guards");
                         assert!(
                             arm.attrs.is_empty(),
                             "match_byte doesn't support attributes"


### PR DESCRIPTION
This loses the guard assert in 2.0, but the rest works just fine.

The assert is covered by the panic in syn 3.0.

It's useful to keep 2.0 working since phf_macros does depend on syn 2.0 for now.

Closes #431