### PR TITLE
Upgrade `phf` to 0.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.71.0
+          - 1.85.0
         features:
           -
           - --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ smallvec = "1.0"
 # Optional dependencies
 cssparser-macros = { path = "./macros", version = "0.7.0", optional = true }
 malloc_size_of = { version = "0.1", default-features = false, optional = true }
-phf = { version = "0.13.1", features = ["macros"], optional = true }
+phf = { version = "0.14.0", features = ["macros"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["css", "syntax", "parser"]
 license = "MPL-2.0"
 edition = "2018"
-rust-version = "1.71"
+rust-version = "1.85"
 
 exclude = ["src/css-parsing-tests/**", "src/big-data-url.css"]
 

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -19,6 +19,8 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 [features]
 default = ["cssparser/default"]
 serde = ["cssparser/serde", "dep:serde"]
+# Useful for skipping tests when execution is slow, e.g., under miri
+skip_long_tests = []
 
 [dev-dependencies]
 serde_json = "1.0.25"

--- a/color/Cargo.toml
+++ b/color/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/cssparser-color/"
 repository = "https://github.com/servo/rust-cssparser"
 license = "MPL-2.0"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.85"
 
 [lib]
 path = "lib.rs"

--- a/color/lib.rs
+++ b/color/lib.rs
@@ -464,7 +464,7 @@ where
 /// floating point values.
 struct ModernComponent<'a>(&'a Option<f32>);
 
-impl<'a> ToCss for ModernComponent<'a> {
+impl ToCss for ModernComponent<'_> {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result
     where
         W: fmt::Write,
@@ -1041,7 +1041,7 @@ pub trait ColorParser<'i> {
 /// Default implementation of a [`ColorParser`]
 pub struct DefaultColorParser;
 
-impl<'i> ColorParser<'i> for DefaultColorParser {
+impl ColorParser<'_> for DefaultColorParser {
     type Output = Color;
     type Error = ();
 }

--- a/color/tests.rs
+++ b/color/tests.rs
@@ -69,8 +69,7 @@ fn run_json_tests<F: Fn(&mut Parser) -> Value>(json_data: &str, parse: F) {
 }
 fn run_color_tests<F: Fn(Result<Color, ()>) -> Value>(json_data: &str, to_json: F) {
     run_json_tests(json_data, |input| {
-        let result: Result<_, ParseError<()>> =
-            input.parse_entirely(|i| Color::parse(i).map_err(Into::into));
+        let result: Result<_, ParseError<()>> = input.parse_entirely(|i| Color::parse(i));
         to_json(result.map_err(|_| ()))
     });
 }
@@ -317,7 +316,7 @@ fn generic_parser() {
     }
 
     struct TestColorParser;
-    impl<'i> ColorParser<'i> for TestColorParser {
+    impl ColorParser<'_> for TestColorParser {
         type Output = OutputType;
         type Error = ();
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -52,11 +52,10 @@ fn normalize(json: &mut Value) {
                 normalize(item)
             }
         }
-        Value::String(ref mut s) => {
-            if *s == "extra-input" || *s == "empty" {
-                *s = "invalid".to_string()
-            }
+        Value::String(ref mut s) if *s == "extra-input" || *s == "empty" => {
+            *s = "invalid".to_string()
         }
+
         _ => {}
     }
 }


### PR DESCRIPTION
There is potentially a decent speed boost available behind the experimental new `ptrhash` feature (see: https://github.com/rust-phf/rust-phf/pull/392). But that is not enabled here.