### PR TITLE
cowrcstr: Move owned variant drop out of line.

### DIFF
--- a/src/cow_rc_str.rs
+++ b/src/cow_rc_str.rs
@@ -99,11 +99,17 @@ impl Clone for CowRcStr<'_> {
     }
 }
 
+#[cold]
+#[inline(never)]
+unsafe fn drop_slow(ptr: *const String) {
+    mem::drop(Rc::from_raw(ptr))
+}
+
 impl Drop for CowRcStr<'_> {
     #[inline]
     fn drop(&mut self) {
         if let Err(ptr) = self.unpack() {
-            mem::drop(unsafe { Rc::from_raw(ptr) })
+            unsafe { drop_slow(ptr) }
         }
     }
 }


### PR DESCRIPTION
This reduces the amount of drop glue that the compiler emits for each token significantly, and the owned variant is supposed to be rare already (escaped strings and such).

It'd be better to somehow coalesce the drop of all the variants because there's at most one CowRcStr per token, but it's annoying to do so without changing the shape of Token as a whole / the ergonomics of the library. This still gives a good targeted win.