### PR TITLE
cowrcstr: Remove unnecessary release assert.

### DIFF
--- a/src/cow_rc_str.rs
+++ b/src/cow_rc_str.rs
@@ -42,7 +42,10 @@ impl<'a> From<&'a str> for CowRcStr<'a> {
     #[inline]
     fn from(s: &'a str) -> Self {
         let len = s.len();
-        assert!(len < usize::MAX);
+        // Guaranteed by https://doc.rust-lang.org/stable/reference/types/numeric.html:
+        //     The theoretical upper bound on object and array size is the maximum isize value
+        // (which by definition is smaller than usize::MAX).
+        debug_assert!(len < usize::MAX);
         CowRcStr {
             ptr: unsafe { ptr::NonNull::new_unchecked(s.as_ptr() as *mut ()) },
             borrowed_len_or_max: len,


### PR DESCRIPTION
Rust guarantees that slices are never bigger than isize::MAX.

This came up because I was looking at whether it'd be possible to use one bit of the length field as a tag, and keep the str bytes as the pointer in the owned case too (so the conversion to str is just removing the tag).

But that doesn't seem feasible unless we go to Rc<str> rather than Rc<String>, which would enforce reallocating the escaped strings, which is a bit annoying... So I'm not pursuing that for now.